### PR TITLE
Stream options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ connections and 10 pipelined requests.
 * `pino-http` (extreme): 25770.91 req/sec
 * no logger: 46139.64 req/sec
 
-All benchmarks where taken on a Macbook Pro 2013 (2.6GHZ i7, 16GB of RAM). 
+All benchmarks where taken on a Macbook Pro 2013 (2.6GHZ i7, 16GB of RAM).
 
 ## Install
 
@@ -106,6 +106,10 @@ property
 You can pass a `genReqId` function which gets used to generate a request id. The first argument is the request itself.
 
 As fallback `pino-http` is just using an integer. This default might not be the desired behavior if you're running multiple instances of the app.
+
+##### stream
+The destination stream.  
+Could be passed as the second parameter or as an option.
 
 #### Examples
 

--- a/logger.js
+++ b/logger.js
@@ -12,8 +12,9 @@ function pinoLogger (opts, stream) {
   opts.serializers = opts.serializers || {}
   opts.serializers.req = opts.serializers.req || asReqValue
   opts.serializers.res = opts.serializers.res || pino.stdSerializers.res
+  opts.stream = opts.stream || stream
 
-  var logger = wrapChild(opts, opts.stream || stream)
+  var logger = wrapChild(opts, opts.stream)
   var genReqId = reqIdGenFactory(opts.genReqId)
   loggingMiddleware.logger = logger
   return loggingMiddleware

--- a/logger.js
+++ b/logger.js
@@ -12,9 +12,11 @@ function pinoLogger (opts, stream) {
   opts.serializers = opts.serializers || {}
   opts.serializers.req = opts.serializers.req || asReqValue
   opts.serializers.res = opts.serializers.res || pino.stdSerializers.res
-  opts.stream = opts.stream || stream
 
-  var logger = wrapChild(opts, opts.stream)
+  var theStream = opts.stream || stream
+  delete opts.stream
+
+  var logger = wrapChild(opts, theStream)
   var genReqId = reqIdGenFactory(opts.genReqId)
   loggingMiddleware.logger = logger
   return loggingMiddleware

--- a/logger.js
+++ b/logger.js
@@ -13,7 +13,7 @@ function pinoLogger (opts, stream) {
   opts.serializers.req = opts.serializers.req || asReqValue
   opts.serializers.res = opts.serializers.res || pino.stdSerializers.res
 
-  var logger = wrapChild(opts, stream)
+  var logger = wrapChild(opts, opts.stream || stream)
   var genReqId = reqIdGenFactory(opts.genReqId)
   loggingMiddleware.logger = logger
   return loggingMiddleware

--- a/test.js
+++ b/test.js
@@ -51,6 +51,25 @@ test('default settings', function (t) {
   })
 })
 
+test('stream in options', function (t) {
+  var dest = split(JSON.parse)
+  var logger = pinoHttp({ stream: dest })
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server)
+  })
+
+  dest.on('data', function (line) {
+    t.ok(line.req, 'req is defined')
+    t.ok(line.res, 'res is defined')
+    t.equal(line.msg, 'request completed', 'message is set')
+    t.equal(line.req.method, 'GET', 'method is get')
+    t.equal(line.res.statusCode, 200, 'statusCode is 200')
+    t.end()
+  })
+})
+
 test('exposes the internal pino', function (t) {
   t.plan(1)
 


### PR DESCRIPTION
Added the `stream` option to pass the destination stream inside the `options` object instead of the second parameter.
I left the standalone stream parameter for back compatibility.
(cc https://github.com/mcollina/fastify/pull/25)