### PR TITLE
Print log for aborted connections

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -48,7 +48,7 @@ function pinoLogger (opts, stream) {
 
   function onReqAborted () {
     var res = this.res
-    res.statusCode = 0
+    res.statusCode = 408
     onResFinished.call(res, new Error('Aborted'))
   }
 

--- a/logger.js
+++ b/logger.js
@@ -46,7 +46,8 @@ function pinoLogger (opts, stream) {
     }, 'request completed')
   }
 
-  function onReqAborted (res) {
+  function onReqAborted () {
+    var res = this.res
     res.statusCode = 0
     onResFinished.call(res, new Error('Aborted'))
   }
@@ -55,13 +56,12 @@ function pinoLogger (opts, stream) {
     req.id = genReqId(req)
     req.log = res.log = logger.child({req: req})
     res.startTime = Date.now()
+    if (!req.res) { req.res = res }
 
     res.on('finish', onResFinished)
     res.on('error', onResFinished)
     // it's possible that browser aborts connection, or http-server because of timeout
-    req.on('aborted', function () {
-      onReqAborted(res)
-    })
+    req.on('aborted', onReqAborted)
 
     if (next) {
       next()

--- a/test.js
+++ b/test.js
@@ -29,7 +29,7 @@ function setup (t, logger, cb, handler) {
 
 function doGet (server) {
   var address = server.address()
-  http.get('http://' + address.address + ':' + address.port)
+  return http.get('http://' + address.address + ':' + address.port)
 }
 
 test('default settings', function (t) {
@@ -254,6 +254,79 @@ test('support a custom instance with custom genReqId function', function (t) {
     t.equal(line.msg, 'request completed', 'message is set')
     t.equal(line.req.method, 'GET', 'method is get')
     t.equal(line.res.statusCode, 200, 'statusCode is 200')
+    t.end()
+  })
+})
+
+test('react on aborted event from clientside', function (t) {
+  var dest = split(JSON.parse)
+
+  var idToTest
+  function genReqId (req) {
+    t.ok(req.url, 'The first argument must be the request parameter')
+    idToTest = (Date.now() + Math.random()).toString(32)
+    return idToTest
+  }
+
+  var logger = pinoHttp({
+    logger: pino({
+      serializers: pino.stdSerializers
+    }, dest),
+    genReqId: genReqId
+  })
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    var address = server.address()
+    var request = http.get({
+      host: address.address,
+      port: address.port
+    })
+    // need this in order to prevent unhadled socket handup
+    request.on('error', function () {})
+    setTimeout(function () {
+      // break the connection from the clientside
+      request.abort()
+    }, 100)
+  }, logger)
+
+  dest.on('data', function (line) {
+    t.equal(line.msg, 'request errored', 'message is set')
+    t.equal(line.err.message, 'Aborted', 'error message is set')
+    t.equal(line.res.statusCode, 0, 'statusCode is 0')
+    t.end()
+  })
+})
+
+test('react on aborted event from server', function (t) {
+  var dest = split(JSON.parse)
+
+  var idToTest
+  function genReqId (req) {
+    t.ok(req.url, 'The first argument must be the request parameter')
+    idToTest = (Date.now() + Math.random()).toString(32)
+    return idToTest
+  }
+
+  var logger = pinoHttp({
+    logger: pino({
+      serializers: pino.stdSerializers
+    }, dest),
+    genReqId: genReqId
+  })
+
+  setup(t, logger, function (err, server) {
+    server.timeout = 100
+    t.error(err)
+    var request = doGet(server)
+    // need this in order to prevent unhadled socket handup
+    request.on('error', function () {})
+  }, logger)
+
+  dest.on('data', function (line) {
+    t.equal(line.msg, 'request errored', 'message is set')
+    t.equal(line.err.message, 'Aborted', 'error message is set')
+    t.equal(line.res.statusCode, 0, 'statusCode is 0')
     t.end()
   })
 })

--- a/test.js
+++ b/test.js
@@ -293,7 +293,7 @@ test('react on aborted event from clientside', function (t) {
   dest.on('data', function (line) {
     t.equal(line.msg, 'request errored', 'message is set')
     t.equal(line.err.message, 'Aborted', 'error message is set')
-    t.equal(line.res.statusCode, 0, 'statusCode is 0')
+    t.equal(line.res.statusCode, 408, 'statusCode is 408')
     t.end()
   })
 })
@@ -326,7 +326,7 @@ test('react on aborted event from server', function (t) {
   dest.on('data', function (line) {
     t.equal(line.msg, 'request errored', 'message is set')
     t.equal(line.err.message, 'Aborted', 'error message is set')
-    t.equal(line.res.statusCode, 0, 'statusCode is 0')
+    t.equal(line.res.statusCode, 408, 'statusCode is 408')
     t.end()
   })
 })


### PR DESCRIPTION
It's possible that requests takes so long that it's either aborted by the browser or by the http.Server.
In both cases, there is no log call saying that the connection is dead, which gives the feeling in the logs, that request is still in progress.