### PR TITLE
Added response time to request object for processing by middleware further down the chain

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -29,20 +29,20 @@ function pinoLogger (opts, stream) {
     this.removeListener('error', onResFinished)
 
     var log = this.log
-    var responseTime = Date.now() - this.startTime
+    this.responseTime = Date.now() - this.startTime
 
     if (err) {
       log.error({
         res: this,
         err: err,
-        responseTime: responseTime
+        responseTime: this.responseTime
       }, 'request errored')
       return
     }
 
     log[useLevel]({
       res: this,
-      responseTime: responseTime
+      responseTime: this.responseTime
     }, 'request completed')
   }
 


### PR DESCRIPTION
Context
----------

Currently I am working on a project using [express-pino-logger](https://github.com/pinojs/express-pino-logger) as the logging middleware. I'm in the process of adding a StatsD graphing middleware based on [hot-shots](https://github.com/brightcove/hot-shots) and when recalculating the response time it is usually around ~1ms longer.

Change
----------

In order to use the same figure as [express-pino-logger](https://github.com/pinojs/express-pino-logger) to have consistency between the graphing and logging in the project, I have changed a line in pino-http to store the calculated `responseTime` on the `response` object. This can then be used by the graphing middleware as it is the next one in the chain.