### PR TITLE
use standard err serializer

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -12,6 +12,7 @@ function pinoLogger (opts, stream) {
   opts.serializers = opts.serializers || {}
   opts.serializers.req = opts.serializers.req || asReqValue
   opts.serializers.res = opts.serializers.res || pino.stdSerializers.res
+  opts.serializers.err = opts.serializers.err || pino.stdSerializers.err
 
   var useLevel = opts.useLevel || 'info'
   delete opts.useLevel


### PR DESCRIPTION
hey,

this pull request adds `pino.stdSerializers.err` to the logger serializers.

is there a reason why this was not done before? maybe i'm naive and missing something obvious.

cheers!