### PR TITLE
Respect startTime if already defined

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -2,6 +2,8 @@
 
 var pino = require('pino')
 
+var startTime = Symbol('startTime')
+
 function pinoLogger (opts, stream) {
   if (opts && opts._writableState) {
     stream = opts
@@ -30,7 +32,7 @@ function pinoLogger (opts, stream) {
     this.removeListener('error', onResFinished)
 
     var log = this.log
-    var responseTime = Date.now() - this.startTime
+    var responseTime = Date.now() - this[startTime]
 
     if (err) {
       log.error({
@@ -50,7 +52,7 @@ function pinoLogger (opts, stream) {
   function loggingMiddleware (req, res, next) {
     req.id = genReqId(req)
     req.log = res.log = logger.child({req: req})
-    res.startTime = Date.now()
+    res[startTime] = res[startTime] || Date.now()
     if (!req.res) { req.res = res }
 
     res.on('finish', onResFinished)
@@ -105,3 +107,4 @@ module.exports.stdSerializers = {
   req: asReqValue,
   res: pino.stdSerializers.res
 }
+module.exports.startTime = startTime

--- a/test.js
+++ b/test.js
@@ -164,6 +164,30 @@ test('reuses existing req.id if present', function (t) {
   })
 })
 
+test('startTime', function (t) {
+  var dest = split(JSON.parse)
+  var logger = pinoHttp(dest)
+  var someStartTime = 56
+
+  t.equal(typeof pinoHttp.startTime, 'symbol')
+
+  function loggerWithStartTime (req, res) {
+    res[pinoHttp.startTime] = someStartTime
+    logger(req, res)
+    t.equal(res[pinoHttp.startTime], someStartTime)
+  }
+
+  setup(t, loggerWithStartTime, function (err, server) {
+    t.error(err)
+    doGet(server)
+  })
+
+  dest.on('data', function (line) {
+    t.equal(typeof line.responseTime, 'number')
+    t.end()
+  })
+})
+
 test('responseTime', function (t) {
   var dest = split(JSON.parse)
   var logger = pinoHttp(dest)


### PR DESCRIPTION
Sometimes it's not possible to attach logger in the very beginning of the request, unfortunately `pino-http` overwrites what's there for, what seems to me, no good reason.