### PR TITLE
Fix setting request id

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -121,7 +121,7 @@ function wrapReqSerializer (serializer) {
 function asReqValue (req) {
   var connection = req.connection
   const _req = Object.create(pinoReqProto)
-  _req.id = Function.prototype.isPrototypeOf(req.id) ? req.id() : req.id
+  _req.id = typeof req.id === 'function' ? req.id() : req.id
   _req.method = req.method
   _req.url = req.url
   _req.headers = req.headers

--- a/logger.js
+++ b/logger.js
@@ -121,7 +121,7 @@ function wrapReqSerializer (serializer) {
 function asReqValue (req) {
   var connection = req.connection
   const _req = Object.create(pinoReqProto)
-  _req.id = req.id
+  _req.id = Function.prototype.isPrototypeOf(req.id) ? req.id() : req.id
   _req.method = req.method
   _req.url = req.url
   _req.headers = req.headers

--- a/test.js
+++ b/test.js
@@ -414,3 +414,29 @@ test('res.raw is not enumerable', function (t) {
     res.end()
   }
 })
+
+test('req.id has a non-function value', function (t) {
+  t.plan(1)
+  var dest = split(JSON.parse)
+  var logger = pinoHttp({
+    logger: pino(dest),
+    serializers: {
+      req: function (req) {
+        t.is(Function.isPrototypeOf(req.id), false)
+        return req
+      }
+    }
+  })
+
+  var server = http.createServer(handler)
+  server.unref()
+  server.listen(0, () => {
+    const port = server.address().port
+    http.get(`http://127.0.0.1:${port}`, () => {})
+  })
+
+  function handler (req, res) {
+    logger(req, res)
+    res.end()
+  }
+})

--- a/test.js
+++ b/test.js
@@ -321,8 +321,7 @@ test('does not return excessively long object', function (t) {
   var server = http.createServer(handler)
   server.unref()
   server.listen(0, () => {
-    const port = server.address().port
-    http.get(`http://127.0.0.1:${port}`, () => {})
+    http.get(server.address(), () => {})
   })
 
   function handler (req, res) {
@@ -352,8 +351,7 @@ test('req.raw is available to custom serializers', function (t) {
   var server = http.createServer(handler)
   server.unref()
   server.listen(0, () => {
-    const port = server.address().port
-    http.get(`http://127.0.0.1:${port}`, () => {})
+    http.get(server.address(), () => {})
   })
 
   function handler (req, res) {
@@ -379,8 +377,7 @@ test('res.raw is available to custom serializers', function (t) {
   var server = http.createServer(handler)
   server.unref()
   server.listen(0, () => {
-    const port = server.address().port
-    http.get(`http://127.0.0.1:${port}`, () => {})
+    http.get(server.address(), () => {})
   })
 
   function handler (req, res) {
@@ -405,8 +402,7 @@ test('res.raw is not enumerable', function (t) {
   var server = http.createServer(handler)
   server.unref()
   server.listen(0, () => {
-    const port = server.address().port
-    http.get(`http://127.0.0.1:${port}`, () => {})
+    http.get(server.address(), () => {})
   })
 
   function handler (req, res) {
@@ -422,7 +418,7 @@ test('req.id has a non-function value', function (t) {
     logger: pino(dest),
     serializers: {
       req: function (req) {
-        t.is(Function.isPrototypeOf(req.id), false)
+        t.is(typeof req.id === 'function', false)
         return req
       }
     }
@@ -431,8 +427,7 @@ test('req.id has a non-function value', function (t) {
   var server = http.createServer(handler)
   server.unref()
   server.listen(0, () => {
-    const port = server.address().port
-    http.get(`http://127.0.0.1:${port}`, () => {})
+    http.get(server.address(), () => {})
   })
 
   function handler (req, res) {


### PR DESCRIPTION
While updating `restify-pino-logger` I learned that the request id property was not getting set properly. I'm don't know how it ever was. Consider:

1. https://github.com/pinojs/pino-http/blame/626eede60281e460e77968836293d671d709f19a/logger.js#L53
1. https://github.com/pinojs/pino-http/blame/626eede60281e460e77968836293d671d709f19a/logger.js#L82

First it's set to a function and then that function is assigned to the property.

This PR simply invokes the `req.id` function in the serializer if it is actually a function. Otherwise it assigns whatever that value is to the property.