### PR TITLE
Fix request on error logger

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -34,7 +34,7 @@ function pinoLogger (opts, stream) {
     var log = this.log
     var responseTime = Date.now() - this[startTime]
 
-    if (err || this.err || this.statusCode >= 400) {
+    if (err || this.err || this.statusCode >= 500) {
       log.error({
         res: this,
         err: err || this.err || new Error('failed with status code' + this.statusCode),

--- a/logger.js
+++ b/logger.js
@@ -27,16 +27,17 @@ function pinoLogger (opts, stream) {
   loggingMiddleware.logger = logger
   return loggingMiddleware
 
-  function onResFinished () {
+  function onResFinished (err) {
+    this.removeListener('error', onResFinished)
     this.removeListener('finish', onResFinished)
 
     var log = this.log
     var responseTime = Date.now() - this[startTime]
 
-    if (this.err || this.statusCode >= 400) {
+    if (err || this.err || this.statusCode >= 400) {
       log.error({
         res: this,
-        err: this.err || new Error('failed with status code' + this.statusCode),
+        err: err || this.err || new Error('failed with status code' + this.statusCode),
         responseTime: responseTime
       }, 'request errored')
       return
@@ -55,6 +56,7 @@ function pinoLogger (opts, stream) {
     if (!req.res) { req.res = res }
 
     res.on('finish', onResFinished)
+    res.on('error', onResFinished)
 
     if (next) {
       next()

--- a/logger.js
+++ b/logger.js
@@ -27,17 +27,16 @@ function pinoLogger (opts, stream) {
   loggingMiddleware.logger = logger
   return loggingMiddleware
 
-  function onResFinished (err) {
+  function onResFinished () {
     this.removeListener('finish', onResFinished)
-    this.removeListener('error', onResFinished)
 
     var log = this.log
     var responseTime = Date.now() - this[startTime]
 
-    if (err) {
+    if (this.err || this.statusCode >= 400) {
       log.error({
         res: this,
-        err: err,
+        err: this.err || new Error('failed with status code' + this.statusCode),
         responseTime: responseTime
       }, 'request errored')
       return
@@ -56,7 +55,6 @@ function pinoLogger (opts, stream) {
     if (!req.res) { req.res = res }
 
     res.on('finish', onResFinished)
-    res.on('error', onResFinished)
 
     if (next) {
       next()

--- a/test.js
+++ b/test.js
@@ -218,6 +218,21 @@ test('responseTime for errored request', function (t) {
   expectResponseTime(t, dest, logger, handle)
 })
 
+test('responseTime for request emitting error event', function (t) {
+  var dest = split(JSON.parse)
+  var logger = pinoHttp(dest)
+
+  function handle (req, res) {
+    logger(req, res)
+    setTimeout(function () {
+      res.emit('error', new Error('Some error'))
+      res.end()
+    }, 100)
+  }
+
+  expectResponseTime(t, dest, logger, handle)
+})
+
 function expectResponseTime (t, dest, logger, handle) {
   setup(t, logger, function (err, server) {
     t.error(err)

--- a/test.js
+++ b/test.js
@@ -209,7 +209,8 @@ test('responseTime for errored request', function (t) {
   function handle (req, res) {
     logger(req, res)
     setTimeout(function () {
-      res.emit('error', new Error('Some error'))
+      res.err = new Error('Some error')
+      res.emit('finished')
       res.end()
     }, 100)
   }


### PR DESCRIPTION
The `err` param in `onResFinished(err)` was always `undefined` no matter what the result of the request was.

From nodejs / express documentation, there is no event named `error`:
- https://expressjs.com/en/4x/api.html#res
- https://nodejs.org/api/http.html#http_class_http_serverresponse

The `res` object can be used as a the `err` holder, and set on the `res` object in the express error handler middleware 
```js
function onErrorMiddleware(err, req, res, next) {
    res.err = err;
    //code
}
```

If no `err` object on the response but a bad `statusCode`, we generate the error from the logger. I know this would show a somewhat confusing stack, but it's something. 
Besides the `stdSerializers.err` handles string error as an array of chars.