### PR TITLE
Refactor to use pino-std-serializers

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "High-speed HTTP logger for Node.js",
   "main": "logger.js",
   "dependencies": {
-    "pino": "^4.10.2"
+    "pino": "^4.10.2",
+    "pino-std-serializers": "^1.0.0"
   },
   "devDependencies": {
     "autocannon": "^0.16.5",


### PR DESCRIPTION
Remove code that is duplicated in the `pino-std-serializers` module.