### PR TITLE
Fix message formatting in request error fallback

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -38,7 +38,7 @@ function pinoLogger (opts, stream) {
     if (err || this.err || this.statusCode >= 500) {
       log.error({
         res: this,
-        err: err || this.err || new Error('failed with status code' + this.statusCode),
+        err: err || this.err || new Error('failed with status code ' + this.statusCode),
         responseTime: responseTime
       }, 'request errored')
       return


### PR DESCRIPTION
The fallback error message didn't contain a space:
`"err":{"type":"Error","message":"failed with status code500",`

The updated message now looks like:
`"err":{"type":"Error","message":"failed with status code 500",`