### PR TITLE
Better formatting for default error

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -38,7 +38,7 @@ function pinoLogger (opts, stream) {
     if (err || this.err || this.statusCode >= 500) {
       log.error({
         res: this,
-        err: err || this.err || new Error('failed with status code' + this.statusCode),
+        err: err || this.err || new Error('failed with status code ' + this.statusCode),
         responseTime: responseTime
       }, 'request errored')
       return


### PR DESCRIPTION
Would previously log a message like `failed with status code500`, this PR simply adds a space between the status code and the supporting text: `failed with status code 500`