### PR TITLE
add support for wrapping the default error serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ $ node example.js | pino
 * `genReqId`: you can pass a function which gets used to generate a request id. The first argument is the request itself. As fallback `pino-http` is just using an integer. This default might not be the desired behavior if you're running multiple instances of the app
 * `useLevel`: the logger level `pino-http` is using to log out the response. default: `info`
 * `customLogLevel`: set to a `function (res, err) => { /* returns level name string */ }`. This function will be invoked to determine the level at which the log should be issued. This option is mutually exclusive with the `useLevel` option. The first argument is the HTTP response. The second argument is an error object if an error has occurred in the request.
-
 * `stream`: same as the second parameter
 
 `stream`: the destination stream. Could be passed in as an option too.
@@ -121,6 +120,7 @@ var logger = require('pino-http')({
 
   // Define custom serializers
   serializers: {
+    err: pino.stdSerializers.err,
     req: pino.stdSerializers.req,
     res: pino.stdSerializers.res
   },
@@ -234,13 +234,15 @@ properties, in the resulting logs, we can supply a serializer like:
 ```js
 var http = require('http')
 var logger = require('pino-http')({
-  serializers: function (req) {
-    Object.keys(req.raw).forEach((k) => {
-      if (k.startsWith('foo')) {
-        req[k] = req.raw[k]
-      }
-    })
-    return req
+  serializers: {
+    req (req) {
+      Object.keys(req.raw).forEach((k) => {
+        if (k.startsWith('foo')) {
+          req[k] = req.raw[k]
+        }
+      })
+      return req
+    }
   }
 })
 ```

--- a/logger.js
+++ b/logger.js
@@ -15,7 +15,7 @@ function pinoLogger (opts, stream) {
   opts.serializers = opts.serializers || {}
   opts.serializers.req = serializers.wrapRequestSerializer(opts.serializers.req || serializers.req)
   opts.serializers.res = serializers.wrapResponseSerializer(opts.serializers.res || serializers.res)
-  opts.serializers.err = opts.serializers.err || serializers.err
+  opts.serializers.err = serializers.wrapErrorSerializer(opts.serializers.err || serializers.err)
 
   if (opts.useLevel && opts.customLogLevel) {
     throw new Error("You can't pass 'useLevel' and 'customLogLevel' together")
@@ -101,6 +101,7 @@ function reqIdGenFactory (func) {
 
 module.exports = pinoLogger
 module.exports.stdSerializers = {
+  err: serializers.err,
   req: serializers.req,
   res: serializers.res
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "logger.js",
   "dependencies": {
     "pino": "^5.0.0",
-    "pino-std-serializers": "^2.1.0"
+    "pino-std-serializers": "^2.4.0"
   },
   "devDependencies": {
     "autocannon": "^2.4.1",

--- a/test.js
+++ b/test.js
@@ -381,6 +381,30 @@ test('does not return excessively long object', function (t) {
   })
 })
 
+test('err.raw is available to custom serializers', function (t) {
+  t.plan(1)
+  const error = new Error('foo')
+  const dest = split(JSON.parse)
+  const logger = pinoHttp({
+    logger: pino(dest),
+    serializers: {
+      err (err) {
+        t.equal(err.raw, error)
+      }
+    }
+  })
+
+  const server = http.createServer((req, res) => {
+    logger(req, res)
+    res.err = error
+    res.end()
+  })
+  server.unref()
+  server.listen(0, () => {
+    http.get(server.address(), () => {})
+  })
+})
+
 test('req.raw is available to custom serializers', function (t) {
   t.plan(2)
   var dest = split(JSON.parse)


### PR DESCRIPTION
Tests will fail initially b/c depends on https://github.com/pinojs/pino-std-serializers/pull/18. Will need to bump version of pino-std-serializers.