### PR TITLE
Upgrade pino-std-serializers to avoid DeprecationWarnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "logger.js",
   "dependencies": {
     "pino": "^5.0.0",
-    "pino-std-serializers": "^2.4.0"
+    "pino-std-serializers": "^2.4.2"
   },
   "devDependencies": {
     "autocannon": "^2.4.1",


### PR DESCRIPTION
Pull in the latest version of pino-std-serializers to update how the response
headers are retrieved when logging and avoid getting DeprecationWarnings in
Node 12.