### PR TITLE
Fix #23 use getHeaders() instead of deprecated _headers (#24)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "logger.js",
   "dependencies": {
     "pino": "^5.0.0",
-    "pino-std-serializers": "^2.4.0"
+    "pino-std-serializers": "^2.4.2"
   },
   "devDependencies": {
     "autocannon": "^2.4.1",


### PR DESCRIPTION
Bump pino-std-serializers patch version dependency to apply the fix to avoid the deprecation _headers warning.