### PR TITLE
Add log request body example

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ var logger = require('pino-http')({
 
 Logging of requests' bodies is disabled by default since it can cause security risks such as having private user information (password, other GDPR-protected data, etc.) logged (and persisted in most setups). However if enabled, sensitive information can be redacted as per [redaction documentation](http://getpino.io/#/docs/redaction).
 
-Furthermore, logging more bytes does slow down throughput ([although the cost is negligible in most use cases](https://www.eschrade.com/page/the-cost-of-logging/)).
+Furthermore, logging more bytes does slow down throughput. [This video by pino maintainers Matteo Collina & David Mark Clements](https://www.youtube.com/watch?v=zja-_IYNrFc&feature=youtu.be) goes into this in more detail.
 
 After considering these factors, logging of the request body can be adchieved as follows:
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,11 @@ var logger = require('pino-http')({
 })
 ```
 
-Logging of requests' bodies is disabled by default since it can cause security risks such as having private user information (password, other GDPR-protected data, etc.) logged (and persisted in most setups). But if no such risk is present, and logging of the request body is desired, here is how:
+Logging of requests' bodies is disabled by default since it can cause security risks such as having private user information (password, other GDPR-protected data, etc.) logged (and persisted in most setups). However if enabled, sensitive information can be redacted as per [redaction documentation](http://getpino.io/#/docs/redaction).
+
+Furthermore, logging more bytes does slow down throughput ([although the cost is negligible in most use cases](https://www.eschrade.com/page/the-cost-of-logging/)).
+
+After considering these factors, logging of the request body can be adchieved as follows:
 
 ```js
 const http = require('http')

--- a/README.md
+++ b/README.md
@@ -248,6 +248,20 @@ var logger = require('pino-http')({
 })
 ```
 
+Another common use case is to log requests' bodies, which are not logged by default:
+
+```js
+const http = require('http')
+const logger = require('pino-http')({
+  serializers: {
+    req(req) {
+      req.body = req.raw.body;
+      return req;
+    },
+  },
+});
+```
+
 ## Team
 
 ### Matteo Collina

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ var logger = require('pino-http')({
 })
 ```
 
-Another common use case is to log requests' bodies, which are not logged by default:
+Logging of requests' bodies is disabled by default since it can cause security risks such as having private user information (password, other GDPR-protected data, etc.) logged (and persisted in most setups). But if no such risk is present, and logging of the request body is desired, here is how:
 
 ```js
 const http = require('http')


### PR DESCRIPTION
Adds an example for a common use case of wanting the request body logged.