### PR TITLE
Add autologgingOptions to ignore certain paths like those for health checks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $ node example.js | pino
 * `customLogLevel`: set to a `function (res, err) => { /* returns level name string */ }`. This function will be invoked to determine the level at which the log should be issued. This option is mutually exclusive with the `useLevel` option. The first argument is the HTTP response. The second argument is an error object if an error has occurred in the request.
 * `autoLogging`: set to `false` to disable the automatic "request completed" and "request errored" logging. Defaults to `true`.
 * `autoLoggingOptions`: additional options when `autoLogging == true`.
-* `autoLoggingOptions.ignorePaths`: array that holds one or many paths that should not autolog on completion. Paths should be written as javascript regex patterns. If the path fails, it will still autolog. This is useful for e.g. health check paths that get called every X seconds, and would fill out our logs unnecessarily. 
+* `autoLoggingOptions.ignorePaths`: array that holds one or many paths that should not autolog on completion. Paths will be matched exactly to the url path property (using Node URL class). If the path fails, it will still autolog. This is useful for e.g. health check paths that get called every X seconds, and would fill out our logs unnecessarily.
 * `stream`: same as the second parameter
 
 `stream`: the destination stream. Could be passed in as an option too.

--- a/README.md
+++ b/README.md
@@ -97,9 +97,8 @@ $ node example.js | pino
 * `genReqId`: you can pass a function which gets used to generate a request id. The first argument is the request itself. As fallback `pino-http` is just using an integer. This default might not be the desired behavior if you're running multiple instances of the app
 * `useLevel`: the logger level `pino-http` is using to log out the response. default: `info`
 * `customLogLevel`: set to a `function (res, err) => { /* returns level name string */ }`. This function will be invoked to determine the level at which the log should be issued. This option is mutually exclusive with the `useLevel` option. The first argument is the HTTP response. The second argument is an error object if an error has occurred in the request.
-* `autoLogging`: set to `false` to disable the automatic "request completed" and "request errored" logging. Defaults to `true`.
-* `autoLoggingOptions`: additional options when `autoLogging == true`.
-* `autoLoggingOptions.ignorePaths`: array that holds one or many paths that should not autolog on completion. Paths will be matched exactly to the url path (using Node class `URL.pathname`). This is useful for ignoring e.g. health check paths that get called every X seconds, and would fill out our logs unnecessarily. If the path matches and succeeds (http 200), it will not log any text. If it fails, it will log the error (as with any other path).
+* `autoLogging`: set to `false`, to disable the automatic "request completed" and "request errored" logging. Defaults to `true`. If set to an object, you can provide more options.
+* `autoLogging.ignorePaths`: array that holds one or many paths that should not autolog on completion. Paths will be matched exactly to the url path (using Node class `URL.pathname`). This is useful for ignoring e.g. health check paths that get called every X seconds, and would fill out the logs unnecessarily. If the path matches and succeeds (http 200), it will not log any text. If it fails, it will log the error (as with any other path).
 * `stream`: same as the second parameter
 
 `stream`: the destination stream. Could be passed in as an option too.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $ node example.js | pino
 * `customLogLevel`: set to a `function (res, err) => { /* returns level name string */ }`. This function will be invoked to determine the level at which the log should be issued. This option is mutually exclusive with the `useLevel` option. The first argument is the HTTP response. The second argument is an error object if an error has occurred in the request.
 * `autoLogging`: set to `false` to disable the automatic "request completed" and "request errored" logging. Defaults to `true`.
 * `autoLoggingOptions`: additional options when `autoLogging == true`.
-* `autoLoggingOptions.ignorePaths`: array that holds one or many paths that should not autolog on completion. Paths will be matched exactly to the url path property (using Node URL class). If the path fails, it will still autolog. This is useful for e.g. health check paths that get called every X seconds, and would fill out our logs unnecessarily.
+* `autoLoggingOptions.ignorePaths`: array that holds one or many paths that should not autolog on completion. Paths will be matched exactly to the url path (using Node class `URL.pathname`). This is useful for ignoring e.g. health check paths that get called every X seconds, and would fill out our logs unnecessarily. If the path matches and succeeds (http 200), it will not log any text. If it fails, it will log the error (as with any other path).
 * `stream`: same as the second parameter
 
 `stream`: the destination stream. Could be passed in as an option too.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ $ node example.js | pino
 * `useLevel`: the logger level `pino-http` is using to log out the response. default: `info`
 * `customLogLevel`: set to a `function (res, err) => { /* returns level name string */ }`. This function will be invoked to determine the level at which the log should be issued. This option is mutually exclusive with the `useLevel` option. The first argument is the HTTP response. The second argument is an error object if an error has occurred in the request.
 * `autoLogging`: set to `false` to disable the automatic "request completed" and "request errored" logging. Defaults to `true`.
+* `autoLoggingOptions`: additional options when `autoLogging == true`.
+* `autoLoggingOptions.ignorePaths`: array that holds one or many paths that should not autolog on completion. Paths should be written as javascript regex patterns. If the path fails, it will still autolog. This is useful for e.g. health check paths that get called every X seconds, and would fill out our logs unnecessarily. 
 * `stream`: same as the second parameter
 
 `stream`: the destination stream. Could be passed in as an option too.

--- a/logger.js
+++ b/logger.js
@@ -36,7 +36,8 @@ function pinoLogger (opts, stream) {
   var autoLogging = (opts.autoLogging !== false)
   delete opts.autoLogging
 
-  var autoLoggingOptions = opts.autoLoggingOptions
+  var autoLoggingIgnorePaths = opts.autoLoggingOptions.ignorePaths
+  delete opts.autoLoggingOptions.ignorePaths
   delete opts.autoLoggingOptions
 
   var logger = wrapChild(opts, theStream)
@@ -62,8 +63,10 @@ function pinoLogger (opts, stream) {
     }
 
     var shouldLogSuccess = true
-    if (this._currentUrl && autoLoggingOptions && autoLoggingOptions.ignorePaths && autoLoggingOptions.ignorePaths.length) {
-      shouldLogSuccess = autoLoggingOptions.ignorePaths.find(x => this._currentUrl.match(x)) == null
+    if (this._currentUrl && autoLoggingIgnorePaths.length) {
+      for (let i = 0; shouldLogSuccess && i < autoLoggingIgnorePaths.length; i++) {
+        shouldLogSuccess = this._currentUrl.match(autoLoggingIgnorePaths[i]) == null
+      }
     }
 
     if (shouldLogSuccess) {

--- a/logger.js
+++ b/logger.js
@@ -77,9 +77,9 @@ function pinoLogger (opts, stream) {
 
     if (autoLogging) {
       if (req.url && autoLoggingIgnorePaths.length) {
-        for (let i = 0; shouldLogSuccess && i < autoLoggingIgnorePaths.length; i++) {
-          shouldLogSuccess = req.url.match(autoLoggingIgnorePaths[i]) == null
-        }
+        // force the base, because req.url will not have it and URL class needs it.
+        var url = new URL(req.url, 'http://localhost')
+        shouldLogSuccess = !autoLoggingIgnorePaths.includes(url.pathname)
       }
 
       if (shouldLogSuccess) {

--- a/logger.js
+++ b/logger.js
@@ -69,12 +69,13 @@ function pinoLogger (opts, stream) {
   }
 
   function loggingMiddleware (req, res, next) {
+    var shouldLogSuccess = true
+
     req.id = genReqId(req)
     req.log = res.log = logger.child({req: req})
     res[startTime] = res[startTime] || Date.now()
 
     if (autoLogging) {
-      var shouldLogSuccess = true
       if (req.url && autoLoggingIgnorePaths.length) {
         for (let i = 0; shouldLogSuccess && i < autoLoggingIgnorePaths.length; i++) {
           shouldLogSuccess = req.url.match(autoLoggingIgnorePaths[i]) == null

--- a/logger.js
+++ b/logger.js
@@ -62,12 +62,10 @@ function pinoLogger (opts, stream) {
       return
     }
 
-    if (this.shouldLogSuccess) {
-      log[level]({
-        res: this,
-        responseTime: responseTime
-      }, 'request completed')
-    }
+    log[level]({
+      res: this,
+      responseTime: responseTime
+    }, 'request completed')
   }
 
   function loggingMiddleware (req, res, next) {
@@ -85,8 +83,10 @@ function pinoLogger (opts, stream) {
         }
       }
 
-      res.shouldLogSuccess = shouldLogSuccess
-      res.on('finish', onResFinished)
+      if (shouldLogSuccess) {
+        res.on('finish', onResFinished)
+      }
+
       res.on('error', onResFinished)
     }
 

--- a/logger.js
+++ b/logger.js
@@ -2,8 +2,7 @@
 
 var pino = require('pino')
 var serializers = require('pino-std-serializers')
-var URL = require('url').URL
-
+var URL = require('fast-url-parser')
 var startTime = Symbol('startTime')
 
 function pinoLogger (opts, stream) {
@@ -78,8 +77,7 @@ function pinoLogger (opts, stream) {
 
     if (autoLogging) {
       if (req.url && autoLoggingIgnorePaths.length) {
-        // force the base, because req.url will not have it and URL class needs it.
-        var url = new URL(req.url, 'http://localhost')
+        var url = URL.parse(req.url)
         shouldLogSuccess = !autoLoggingIgnorePaths.includes(url.pathname)
       }
 

--- a/logger.js
+++ b/logger.js
@@ -30,7 +30,7 @@ function pinoLogger (opts, stream) {
   delete opts.stream
 
   var autoLogging = (opts.autoLogging !== false)
-  var autoLoggingIgnorePaths = ((opts.autoLogging || {}).ignorePaths || [])
+  var autoLoggingIgnorePaths = (opts.autoLogging && opts.autoLogging.ignorePaths) ? opts.autoLogging.ignorePaths : []
   delete opts.autoLogging
 
   var logger = wrapChild(opts, theStream)

--- a/logger.js
+++ b/logger.js
@@ -16,8 +16,6 @@ function pinoLogger (opts, stream) {
   opts.serializers.req = serializers.wrapRequestSerializer(opts.serializers.req || serializers.req)
   opts.serializers.res = serializers.wrapResponseSerializer(opts.serializers.res || serializers.res)
   opts.serializers.err = serializers.wrapErrorSerializer(opts.serializers.err || serializers.err)
-  opts.autoLoggingOptions = opts.autoLoggingOptions || {}
-  opts.autoLoggingOptions.ignorePaths = opts.autoLoggingOptions.ignorePaths || []
 
   if (opts.useLevel && opts.customLogLevel) {
     throw new Error("You can't pass 'useLevel' and 'customLogLevel' together")
@@ -31,14 +29,9 @@ function pinoLogger (opts, stream) {
   var theStream = opts.stream || stream
   delete opts.stream
 
-  // autoLogging && found in ignore.path => do not log
-  //                not found            => log as usual
   var autoLogging = (opts.autoLogging !== false)
+  var autoLoggingIgnorePaths = ((opts.autoLogging || {}).ignorePaths || [])
   delete opts.autoLogging
-
-  var autoLoggingIgnorePaths = opts.autoLoggingOptions.ignorePaths
-  delete opts.autoLoggingOptions.ignorePaths
-  delete opts.autoLoggingOptions
 
   var logger = wrapChild(opts, theStream)
   var genReqId = reqIdGenFactory(opts.genReqId)

--- a/logger.js
+++ b/logger.js
@@ -74,8 +74,6 @@ function pinoLogger (opts, stream) {
     res[startTime] = res[startTime] || Date.now()
 
     if (autoLogging) {
-      // calculate here whether to log success, but apply this flag up to the last minute.
-      // this is to ensure that the event listener still executes (as there may be other logic that is needed).
       var shouldLogSuccess = true
       if (req.url && autoLoggingIgnorePaths.length) {
         for (let i = 0; shouldLogSuccess && i < autoLoggingIgnorePaths.length; i++) {

--- a/logger.js
+++ b/logger.js
@@ -2,6 +2,7 @@
 
 var pino = require('pino')
 var serializers = require('pino-std-serializers')
+var URL = require('url').URL
 
 var startTime = Symbol('startTime')
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "High-speed HTTP logger for Node.js",
   "main": "logger.js",
   "dependencies": {
+    "fast-url-parser": "^1.1.3",
     "pino": "^5.0.0",
     "pino-std-serializers": "^2.4.0"
   },

--- a/test.js
+++ b/test.js
@@ -296,8 +296,7 @@ test('no auto logging with autoLogging set to false', function (t) {
 test('no auto logging with autoLogging set to true and path ignored', function (t) {
   var dest = split(JSON.parse)
   var logger = pinoHttp({
-    autoLogging: true,
-    autoLoggingOptions: {
+    autoLogging: {
       ignorePaths: ['/ignorethis']
     }
   }, dest)
@@ -330,8 +329,7 @@ test('no auto logging with autoLogging set to true and path ignored', function (
 test('auto logging with autoLogging set to true and path not ignored', function (t) {
   var dest = split(JSON.parse)
   var logger = pinoHttp({
-    autoLogging: true,
-    autoLoggingOptions: {
+    autoLogging: {
       ignorePaths: ['/ignorethis']
     }
   }, dest)

--- a/test.js
+++ b/test.js
@@ -298,7 +298,7 @@ test('no auto logging with autoLogging set to true and path ignored', function (
   var logger = pinoHttp({
     autoLogging: true,
     autoLoggingOptions: {
-      ignorePaths: ['^/ignorethis$']
+      ignorePaths: ['/ignorethis']
     }
   }, dest)
   var timeout
@@ -332,7 +332,7 @@ test('auto logging with autoLogging set to true and path not ignored', function 
   var logger = pinoHttp({
     autoLogging: true,
     autoLoggingOptions: {
-      ignorePaths: ['^/ignorethis$']
+      ignorePaths: ['/ignorethis']
     }
   }, dest)
   var timeout


### PR DESCRIPTION
I would like to push these changes to allow the library to ignore certain paths to autolog.

This is specially useful if I have a health check path which gets called every 3 seconds. If not ignored this would fill our logs a lot.

My first step is to push this in pino-http, then update koa-pino-logger, and I finally use it on my koa app.

One line that definitely needs feedback is on middleware, since the variable is currently called `_currentUrl` (it can improve) and also I did not have access to request on `onResFinished`.

Also I did not find access to the url's path alone, so I had to use raw url for now.

Well hope this can help and be accepted. I think it delivers a good functionality.