### PR TITLE
Add getPath option to autoLogging when req.url is not suitable for matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ $ node example.js | pino
 * `useLevel`: the logger level `pino-http` is using to log out the response. default: `info`
 * `customLogLevel`: set to a `function (res, err) => { /* returns level name string */ }`. This function will be invoked to determine the level at which the log should be issued. This option is mutually exclusive with the `useLevel` option. The first argument is the HTTP response. The second argument is an error object if an error has occurred in the request.
 * `autoLogging`: set to `false`, to disable the automatic "request completed" and "request errored" logging. Defaults to `true`. If set to an object, you can provide more options.
-* `autoLogging.ignorePaths`: array that holds one or many paths that should not autolog on completion. Paths will be matched exactly to the url path (using Node class `URL.pathname`). This is useful for ignoring e.g. health check paths that get called every X seconds, and would fill out the logs unnecessarily. If the path matches and succeeds (http 200), it will not log any text. If it fails, it will log the error (as with any other path).
+* `autoLogging.ignorePaths`: array that holds one or many paths that should not autolog on completion. Paths will be matched exactly to the url path `req.url` (using Node class `URL.pathname`). This is useful for ignoring e.g. health check paths that get called every X seconds, and would fill out the logs unnecessarily. If the path matches and succeeds (http 200), it will not log any text. If it fails, it will log the error (as with any other path).
+* `autoLogging.getPath`: callback function that returns a path as a string. This is useful for checking `autoLogging.ignorePaths` against a path other than the default `req.url`. e.g. An express server where `req.originalUrl` is preferred.
 * `stream`: same as the second parameter
 
 `stream`: the destination stream. Could be passed in as an option too.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ $ node example.js | pino
 * `customLogLevel`: set to a `function (res, err) => { /* returns level name string */ }`. This function will be invoked to determine the level at which the log should be issued. This option is mutually exclusive with the `useLevel` option. The first argument is the HTTP response. The second argument is an error object if an error has occurred in the request.
 * `autoLogging`: set to `false`, to disable the automatic "request completed" and "request errored" logging. Defaults to `true`. If set to an object, you can provide more options.
 * `autoLogging.ignorePaths`: array that holds one or many paths that should not autolog on completion. Paths will be matched exactly to the url path `req.url` (using Node class `URL.pathname`). This is useful for ignoring e.g. health check paths that get called every X seconds, and would fill out the logs unnecessarily. If the path matches and succeeds (http 200), it will not log any text. If it fails, it will log the error (as with any other path).
-* `autoLogging.getPath`: callback function that returns a path as a string. This is useful for checking `autoLogging.ignorePaths` against a path other than the default `req.url`. e.g. An express server where `req.originalUrl` is preferred.
+* `autoLogging.getPath`: set to a `function (req) => { /* returns path string */ }`. This function will be invoked to return the current path as a string. This is useful for checking `autoLogging.ignorePaths` against a path other than the default `req.url`. e.g. An express server where `req.originalUrl` is preferred.
 * `stream`: same as the second parameter
 
 `stream`: the destination stream. Could be passed in as an option too.

--- a/logger.js
+++ b/logger.js
@@ -31,6 +31,7 @@ function pinoLogger (opts, stream) {
 
   var autoLogging = (opts.autoLogging !== false)
   var autoLoggingIgnorePaths = (opts.autoLogging && opts.autoLogging.ignorePaths) ? opts.autoLogging.ignorePaths : []
+  var autoLoggingGetPath = opts.autoLogging && opts.autoLogging.getPath ? opts.autoLogging.getPath : null
   delete opts.autoLogging
 
   var logger = wrapChild(opts, theStream)
@@ -69,9 +70,16 @@ function pinoLogger (opts, stream) {
     res[startTime] = res[startTime] || Date.now()
 
     if (autoLogging) {
-      if (req.url && autoLoggingIgnorePaths.length) {
-        var url = URL.parse(req.url)
-        shouldLogSuccess = !autoLoggingIgnorePaths.includes(url.pathname)
+      if (autoLoggingIgnorePaths.length) {
+        var url
+        if (autoLoggingGetPath) {
+          url = URL.parse(autoLoggingGetPath(req))
+        } else if (req.url) {
+          url = URL.parse(req.url)
+        }
+        if (url && url.pathname) {
+          shouldLogSuccess = !autoLoggingIgnorePaths.includes(url.pathname)
+        }
       }
 
       if (shouldLogSuccess) {


### PR DESCRIPTION
Hello, thanks for the awesome module!

This PR adds a new callback function `getPath` to the autoLogging options which allows implementers to supply a path when checking against `ignorePaths` instead of relying on the default `req.url`.

This issue came up when we tried to implement pino-http into our Nestjs application using the [nestjs-pino](https://github.com/iamolegga/nestjs-pino) library and found that due to how the middleware is injected express was stripping the `req.url` as [documented here](https://expressjs.com/en/api.html#req.originalUrl). This led me to believe the best way to get the functionality we needed was to allow the implementer to supply the current path as a callback function.

An example of how we would use this in our config.
```
{
  autoLogging: {
    ignorePaths: ['/health'],
    getPath: req => req.originalUrl
 }
}
```

FYI I also put up this PR as I noticed the typescript definitions were out of date with the most recent release. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43137