### PR TITLE
[#95] Add option to prevent serializers from being wrapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ var logger = require('pino-http')({
     res: pino.stdSerializers.res
   },
 
+  // Prevent serializers from being wrapped with std serializers
+  // (useful if you want to honor the serializers defined by `opts.logger`)
+  wrapSerializers: false,
+
   // Logger level is `info` by default
   useLevel: 'info',
 
@@ -259,7 +263,6 @@ by `foo`. In order to show these properties, along with the standard serialized
 properties, in the resulting logs, we can supply a serializer like:
 
 ```js
-var http = require('http')
 var logger = require('pino-http')({
   serializers: {
     req (req) {
@@ -274,10 +277,11 @@ var logger = require('pino-http')({
 })
 ```
 
-If you prefer to work with the raw value directly, you can pass in `opts.wrapSerializers` as `false`:
+If you prefer to work with the raw value directly, or you want to honor the custom
+serializers already defined by `opts.logger`, you can pass in `opts.wrapSerializers`
+as `false`:
 
 ```js
-var http = require('http')
 var logger = require('pino-http')({
   wrapSerializers: false,
   serializers: {

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ node example.js | pino-pretty
 * `customSuccessMessage`: set to a `function (res) => { /* returns message string */ }` This function will be invoked at each successful response, setting "msg" property to returned string. If not set, default value will be used.
 * `customErrorMessage`: set to a `function (res, err) => { /* returns message  string */ }` This function will be invoked at each failed response, setting "msg" property to returned string. If not set, default value will be used.
 * `customAttributeKeys`: allows the log object attributes added by `pino-http` to be given custom keys. Accepts an object of format `{ [original]: [override] }`. Attributes available for override are `req`, `res`, `err`, and `responseTime`. 
-* `wrapSerializers`: when false, custom serializers will be passed the raw value directly. Defaults to true
+* `wrapSerializers`: when `false`, custom serializers will be passed the raw value directly. Defaults to `true`.
 
 `stream`: the destination stream. Could be passed in as an option too.
 

--- a/README.md
+++ b/README.md
@@ -132,9 +132,8 @@ var logger = require('pino-http')({
     res: pino.stdSerializers.res
   },
 
-  // Prevent serializers from being wrapped with std serializers
-  // (useful if you want to honor the serializers defined by `opts.logger`)
-  wrapSerializers: false,
+  // Set to `false` to prevent standard serializers from being wrapped.
+  wrapSerializers: true,
 
   // Logger level is `info` by default
   useLevel: 'info',

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ $ node example.js | pino-pretty
 * `customSuccessMessage`: set to a `function (res) => { /* returns message string */ }` This function will be invoked at each successful response, setting "msg" property to returned string. If not set, default value will be used.
 * `customErrorMessage`: set to a `function (res, err) => { /* returns message  string */ }` This function will be invoked at each failed response, setting "msg" property to returned string. If not set, default value will be used.
 * `customAttributeKeys`: allows the log object attributes added by `pino-http` to be given custom keys. Accepts an object of format `{ [original]: [override] }`. Attributes available for override are `req`, `res`, `err`, and `responseTime`. 
+* `wrapSerializers`: when false, custom serializers will be passed the raw value directly. Defaults to true
 
 `stream`: the destination stream. Could be passed in as an option too.
 
@@ -268,6 +269,23 @@ var logger = require('pino-http')({
         }
       })
       return req
+    }
+  }
+})
+```
+
+If you prefer to work with the raw value directly, you can pass in `opts.wrapSerializers` as `false`:
+
+```js
+var http = require('http')
+var logger = require('pino-http')({
+  wrapSerializers: false,
+  serializers: {
+    req (req) {
+      // `req` is the raw `IncomingMessage` object, not the already serialized request from `pino.stdSerializers.req`.
+      return {
+        message: req.foo
+      };
     }
   }
 })

--- a/logger.js
+++ b/logger.js
@@ -11,7 +11,7 @@ function pinoLogger (opts, stream) {
     opts = null
   }
 
-  opts = opts || {}
+  opts = Object.assign({}, opts)
 
   opts.customAttributeKeys = opts.customAttributeKeys || {}
   var reqKey = opts.customAttributeKeys.req || 'req'
@@ -22,7 +22,7 @@ function pinoLogger (opts, stream) {
 
   opts.wrapSerializers = 'wrapSerializers' in opts ? opts.wrapSerializers : true
   if (opts.wrapSerializers) {
-    opts.serializers = Object.assign({}, opts.serializers) || {}
+    opts.serializers = Object.assign({}, opts.serializers)
     var requestSerializer = opts.serializers[reqKey] || opts.serializers.req || serializers.req
     var responseSerializer = opts.serializers[resKey] || opts.serializers.res || serializers.res
     var errorSerializer = opts.serializers[errKey] || opts.serializers.err || serializers.err

--- a/logger.js
+++ b/logger.js
@@ -30,6 +30,7 @@ function pinoLogger (opts, stream) {
     opts.serializers[resKey] = serializers.wrapResponseSerializer(responseSerializer)
     opts.serializers[errKey] = serializers.wrapErrorSerializer(errorSerializer)
   }
+  delete opts.wrapSerializers
 
   if (opts.useLevel && opts.customLogLevel) {
     throw new Error("You can't pass 'useLevel' and 'customLogLevel' together")

--- a/logger.js
+++ b/logger.js
@@ -20,13 +20,16 @@ function pinoLogger (opts, stream) {
   var responseTimeKey = opts.customAttributeKeys.responseTime || 'responseTime'
   delete opts.customAttributeKeys
 
-  opts.serializers = opts.serializers || {}
-  var requestSerializer = opts.serializers[reqKey] || opts.serializers.req || serializers.req
-  var responseSerializer = opts.serializers[resKey] || opts.serializers.res || serializers.res
-  var errorSerializer = opts.serializers[errKey] || opts.serializers.err || serializers.err
-  opts.serializers[reqKey] = serializers.wrapRequestSerializer(requestSerializer)
-  opts.serializers[resKey] = serializers.wrapResponseSerializer(responseSerializer)
-  opts.serializers[errKey] = serializers.wrapErrorSerializer(errorSerializer)
+  opts.wrapSerializers = 'wrapSerializers' in opts ? opts.wrapSerializers : true
+  if (opts.wrapSerializers) {
+    opts.serializers = Object.assign({}, opts.serializers) || {}
+    var requestSerializer = opts.serializers[reqKey] || opts.serializers.req || serializers.req
+    var responseSerializer = opts.serializers[resKey] || opts.serializers.res || serializers.res
+    var errorSerializer = opts.serializers[errKey] || opts.serializers.err || serializers.err
+    opts.serializers[reqKey] = serializers.wrapRequestSerializer(requestSerializer)
+    opts.serializers[resKey] = serializers.wrapResponseSerializer(responseSerializer)
+    opts.serializers[errKey] = serializers.wrapErrorSerializer(errorSerializer)
+  }
 
   if (opts.useLevel && opts.customLogLevel) {
     throw new Error("You can't pass 'useLevel' and 'customLogLevel' together")


### PR DESCRIPTION
Fixes #95

Summary
1) Add `opts.wrapSerializers` to allow consumers to disable wrapping them with the standard serializers
   - This importantly ensures serializers applied to `opts.logger` are not always overridden with the default serializers.
2) Avoid mutating `opts` and `opts.serializers`