### PR TITLE
Remove trailing space in error message

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -50,7 +50,7 @@ function pinoLogger (opts, stream) {
   delete opts.autoLogging
 
   var successMessage = opts.customSuccessMessage || function () { return 'request completed' }
-  var errorMessage = opts.customErrorMessage || function () { return 'request errored ' }
+  var errorMessage = opts.customErrorMessage || function () { return 'request errored' }
   delete opts.customSuccessfulMessage
   delete opts.customErroredMessage
 

--- a/test.js
+++ b/test.js
@@ -257,6 +257,7 @@ test('responseTime for errored request', function (t) {
 
   dest.on('data', function (line) {
     t.ok(line.responseTime >= 0, 'responseTime is defined')
+    t.equal(line.msg, 'request errored', 'message is set')
     t.end()
   })
 })


### PR DESCRIPTION
Currently causing the tests to fail in express-pino-logger:

```text
  not ok message is set
    --- wanted                  
    +++ found                   
    -"request errored"          
    +"request errored "         
```