### PR TITLE
Support regex path matching for autoLogging.ignorePaths option

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -101,7 +101,11 @@ function pinoLogger (opts, stream) {
         }
         if (url && url.pathname) {
           shouldLogSuccess = !autoLoggingIgnorePaths.find(ignorePath => {
-            return new RegExp(ignorePath).test(url.pathname)
+            if (ignorePath instanceof RegExp) {
+              return ignorePath.test(url.pathname)
+            }
+
+            return ignorePath === url.pathname
           })
         }
       }

--- a/logger.js
+++ b/logger.js
@@ -100,7 +100,9 @@ function pinoLogger (opts, stream) {
           url = URL.parse(req.url)
         }
         if (url && url.pathname) {
-          shouldLogSuccess = !autoLoggingIgnorePaths.includes(url.pathname)
+          shouldLogSuccess = !autoLoggingIgnorePaths.find(ignorePath => {
+            return new RegExp(ignorePath).test(url.pathname)
+          })
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pino-http",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "High-speed HTTP logger for Node.js",
   "main": "logger.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pino-http",
-  "version": "5.2.0",
+  "version": "5.1.0",
   "description": "High-speed HTTP logger for Node.js",
   "main": "logger.js",
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -377,6 +377,30 @@ test('auto logging with autoLogging set to true and getPath result is not ignore
   })
 })
 
+test('no auto logging with autoLogging set to use regular expressions. result is ignored', function (t) {
+  var dest = split(JSON.parse)
+  var logger = pinoHttp({
+    autoLogging: {
+      ignorePaths: [/\/[A-z]{4}\/ignorethis/, '/another-ignored-path'],
+      getPath: function (req) {
+        return req.url
+      }
+    }
+  }, dest)
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server, '/abcd/ignorethis')
+    doGet(server, '/another-ignored-path')
+    doGet(server, '/abcd0/shouldlogthis')
+  })
+
+  dest.on('data', function (line) {
+    t.pass('path should log')
+    t.end()
+  })
+})
+
 test('support a custom instance', function (t) {
   var dest = split(JSON.parse)
   var logger = pinoHttp({


### PR DESCRIPTION
I was using the latest version and have a use-case where I want to ignore a dynamic range of paths that can change over time. In order to support this I thought that adding RegExp support to the ignoring mechanism might be an option.

Let me know what you think. Thanks for taking a look.