### PR TITLE
Fix incorrect documentation for customErrorMessage 

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ $ node example.js | pino-pretty
 * `autoLogging.getPath`: set to a `function (req) => { /* returns path string */ }`. This function will be invoked to return the current path as a string. This is useful for checking `autoLogging.ignorePaths` against a path other than the default `req.url`. e.g. An express server where `req.originalUrl` is preferred.
 * `stream`: same as the second parameter
 * `customSuccessMessage`: set to a `function (res) => { /* returns message string */ }` This function will be invoked at each successful response, setting "msg" property to returned string. If not set, default value will be used.
-* `customErrorMessage`: set to a `function (res, err) => { /* returns message  string */ }` This function will be invoked at each failed response, setting "msg" property to returned string. If not set, default value will be used.
-* `customAttributeKeys`: allows the log object attributes added by `pino-http` to be given custom keys. Accepts an object of format `{ [original]: [override] }`. Attributes available for override are `req`, `res`, `err`, and `responseTime`. 
+* `customErrorMessage`: set to a `function (err, res) => { /* returns message string */ }` This function will be invoked at each failed response, setting "msg" property to returned string. If not set, default value will be used.
+* `customAttributeKeys`: allows the log object attributes added by `pino-http` to be given custom keys. Accepts an object of format `{ [original]: [override] }`. Attributes available for override are `req`, `res`, `err`, and `responseTime`.
 * `wrapSerializers`: when `false`, custom serializers will be passed the raw value directly. Defaults to `true`.
-* `reqCustomProps`: set to a `function (req) => { /* returns on object */ }` or `{ /* returns on object */ }` This function will be invoked for each request with `req` where we could pass additional properties that needs to be logged outside the `req`.   
+* `reqCustomProps`: set to a `function (req) => { /* returns on object */ }` or `{ /* returns on object */ }` This function will be invoked for each request with `req` where we could pass additional properties that needs to be logged outside the `req`.
 `stream`: the destination stream. Could be passed in as an option too.
 
 #### Examples
@@ -155,7 +155,7 @@ var logger = require('pino-http')({
     }
     return 'request completed'
   },
-  
+
   // Define a custom error message
   customErrorMessage: function (error, res) {
     return 'request errored with status code: ' + res.statusCode
@@ -167,13 +167,13 @@ var logger = require('pino-http')({
     err: 'error',
     responseTime: 'timeTaken'
   },
-  
+
   // Define additional custom request properties
   reqCustomProps: function (req) {
     return {
       customProp: req.customProp
     }
-  } 
+  }
 })
 
 function handle (req, res) {

--- a/test.js
+++ b/test.js
@@ -671,7 +671,7 @@ test('uses the custom errorMessage callback if passed in as an option', function
   var customErrorMessage = 'Custom error message'
   var logger = pinoHttp({
     customErrorMessage: function (err, res) {
-      return customErrorMessage
+      return customErrorMessage + ' ' + err.toString()
     }
   }, dest)
 
@@ -681,7 +681,7 @@ test('uses the custom errorMessage callback if passed in as an option', function
   })
 
   dest.on('data', function (line) {
-    t.equal(line.msg, customErrorMessage)
+    t.contains(line.msg, customErrorMessage)
     t.end()
   })
 })

--- a/test.js
+++ b/test.js
@@ -650,7 +650,7 @@ test('uses the custom successMessage callback if passed in as an option', functi
   var dest = split(JSON.parse)
   var customResponseMessage = 'Custom response message'
   var logger = pinoHttp({
-    customSuccessMessage: function () {
+    customSuccessMessage: function (res) {
       return customResponseMessage
     }
   }, dest)
@@ -670,7 +670,7 @@ test('uses the custom errorMessage callback if passed in as an option', function
   var dest = split(JSON.parse)
   var customErrorMessage = 'Custom error message'
   var logger = pinoHttp({
-    customErrorMessage: function () {
+    customErrorMessage: function (err, res) {
       return customErrorMessage
     }
   }, dest)


### PR DESCRIPTION
The Readme currently defines the `customErrorMessage` function as having the following signature:

```js
function (res, err) => { /* returns message  string */ }
```

However, the actual implementation
https://github.com/pinojs/pino-http/blob/d593aa6084f1fe70a506ad8f202fc7f339b87fb5/logger.js#L79

Uses `err, res`.

This changes fixes the Readme so that people can use it the right way.
I also added the error to the message in the test to show the use cases for it

I also removed the `package-lock.json` file from the `.gitignore` as that should be checked into source control. Please let me know if it's removed by design.


There is also an error in the `@types/pino-http` package added in https://github.com/DefinitelyTyped/DefinitelyTyped/commit/770b1753b685c22a2a75309ed45058cd66159adb
I'll be fixing that as well.