### PR TITLE
fix: add res to reqCustomProp function signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $ node example.js | pino-pretty
 * `customErrorMessage`: set to a `function (err, res) => { /* returns message string */ }` This function will be invoked at each failed response, setting "msg" property to returned string. If not set, default value will be used.
 * `customAttributeKeys`: allows the log object attributes added by `pino-http` to be given custom keys. Accepts an object of format `{ [original]: [override] }`. Attributes available for override are `req`, `res`, `err`, and `responseTime`.
 * `wrapSerializers`: when `false`, custom serializers will be passed the raw value directly. Defaults to `true`.
-* `reqCustomProps`: set to a `function (req) => { /* returns on object */ }` or `{ /* returns on object */ }` This function will be invoked for each request with `req` where we could pass additional properties that needs to be logged outside the `req`.
+* `reqCustomProps`: set to a `function (req,res) => { /* returns on object */ }` or `{ /* returns on object */ }` This function will be invoked for each request with `req` and `res` where we could pass additional properties that needs to be logged outside the `req`.
 `stream`: the destination stream. Could be passed in as an option too.
 
 #### Examples
@@ -169,9 +169,11 @@ var logger = require('pino-http')({
   },
 
   // Define additional custom request properties
-  reqCustomProps: function (req) {
+  reqCustomProps: function (req,res) {
     return {
-      customProp: req.customProp
+      customProp: req.customProp,
+      // user request-scoped data is in res.locals for express applications
+      customProp2: res.locals.myCustomData
     }
   }
 })

--- a/logger.js
+++ b/logger.js
@@ -94,7 +94,7 @@ function pinoLogger (opts, stream) {
     var log = logger.child({ [reqKey]: req })
 
     if (reqCustomProps) {
-      var customPropBindings = (typeof reqCustomProps === 'function') ? reqCustomProps(req) : reqCustomProps
+      var customPropBindings = (typeof reqCustomProps === 'function') ? reqCustomProps(req, res) : reqCustomProps
       log = log.child(customPropBindings)
     }
     req.log = res.log = log

--- a/package.json
+++ b/package.json
@@ -18,9 +18,10 @@
     "tap": "^14.0.0"
   },
   "scripts": {
-    "benchmark": "./scripts/benchmark-all",
+    "benchmark": "bash ./scripts/benchmark-all",
     "test": "standard && tap --no-cov test.js",
-    "ci": "standard && tap --cov test.js"
+    "ci": "standard && tap --cov test.js",
+    "fix": "standard --fix"
   },
   "author": "David Mark Clements",
   "contributors": [

--- a/test.js
+++ b/test.js
@@ -761,8 +761,8 @@ test('uses custom log object attribute keys when provided, error request', funct
 
 test('uses custom request properties to log additional attributes when provided', function (t) {
   var dest = split(JSON.parse)
-  function customPropsHandler (req) {
-    if (req) {
+  function customPropsHandler (req, res) {
+    if (req && res) {
       return {
         key1: 'value1',
         key2: 'value2'


### PR DESCRIPTION
Added `res` object as additional function parameter to the `reqCustomProps` function
Non-breaking now, but function name will need to be changed in next semver major update, will add PR after this is merged to reuse the branch.

Updated `README.md` and `test.js` with new function signature.

Side effects:

- had to add "bash" to beginning of benchmark command since it relies on bash, and errors out on systems where bash is not the default.
- added "fix" npm script since locally installed `standard` has to be run inside npm script to use local version, and `standard --fix` must be run to get tests to run.

closes #119