### PR TITLE
either reqCustomProps or customProps are valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $ node example.js | pino-pretty
 * `customErrorMessage`: set to a `function (err, res) => { /* returns message string */ }` This function will be invoked at each failed response, setting "msg" property to returned string. If not set, default value will be used.
 * `customAttributeKeys`: allows the log object attributes added by `pino-http` to be given custom keys. Accepts an object of format `{ [original]: [override] }`. Attributes available for override are `req`, `res`, `err`, and `responseTime`.
 * `wrapSerializers`: when `false`, custom serializers will be passed the raw value directly. Defaults to `true`.
-* `reqCustomProps`: set to a `function (req,res) => { /* returns on object */ }` or `{ /* returns on object */ }` This function will be invoked for each request with `req` and `res` where we could pass additional properties that needs to be logged outside the `req`.
+* `customProps`: set to a `function (req,res) => { /* returns on object */ }` or `{ /* returns on object */ }` This function will be invoked for each request with `req` and `res` where we could pass additional properties that needs to be logged outside the `req`.
 `stream`: the destination stream. Could be passed in as an option too.
 
 #### Examples
@@ -169,7 +169,7 @@ var logger = require('pino-http')({
   },
 
   // Define additional custom request properties
-  reqCustomProps: function (req,res) {
+  customProps: function (req,res) {
     return {
       customProp: req.customProp,
       // user request-scoped data is in res.locals for express applications

--- a/logger.js
+++ b/logger.js
@@ -20,7 +20,7 @@ function pinoLogger (opts, stream) {
   var responseTimeKey = opts.customAttributeKeys.responseTime || 'responseTime'
   delete opts.customAttributeKeys
 
-  var customProps = opts.customProps || {}
+  var customProps = opts.customProps || opts.reqCustomProps || {}
 
   opts.wrapSerializers = 'wrapSerializers' in opts ? opts.wrapSerializers : true
   if (opts.wrapSerializers) {

--- a/logger.js
+++ b/logger.js
@@ -20,7 +20,7 @@ function pinoLogger (opts, stream) {
   var responseTimeKey = opts.customAttributeKeys.responseTime || 'responseTime'
   delete opts.customAttributeKeys
 
-  var reqCustomProps = opts.reqCustomProps || {}
+  var customProps = opts.customProps || {}
 
   opts.wrapSerializers = 'wrapSerializers' in opts ? opts.wrapSerializers : true
   if (opts.wrapSerializers) {
@@ -93,8 +93,8 @@ function pinoLogger (opts, stream) {
 
     var log = logger.child({ [reqKey]: req })
 
-    if (reqCustomProps) {
-      var customPropBindings = (typeof reqCustomProps === 'function') ? reqCustomProps(req, res) : reqCustomProps
+    if (customProps) {
+      var customPropBindings = (typeof customProps === 'function') ? customProps(req, res) : customProps
       log = log.child(customPropBindings)
     }
     req.log = res.log = log

--- a/test.js
+++ b/test.js
@@ -785,6 +785,32 @@ test('uses custom request properties to log additional attributes when provided'
   })
 })
 
+test('uses old custom request properties interface to log additional attributes', function (t) {
+  var dest = split(JSON.parse)
+  function customPropsHandler (req, res) {
+    if (req && res) {
+      return {
+        key1: 'value1',
+        key2: 'value2'
+      }
+    }
+  }
+  var logger = pinoHttp({
+    reqCustomProps: customPropsHandler
+  }, dest)
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server)
+  })
+
+  dest.on('data', function (line) {
+    t.equal(line.key1, 'value1')
+    t.equal(line.key2, 'value2')
+    t.end()
+  })
+})
+
 test('uses custom request properties to log additional attributes; custom props is an object instead of callback', function (t) {
   var dest = split(JSON.parse)
   var logger = pinoHttp({

--- a/test.js
+++ b/test.js
@@ -770,7 +770,7 @@ test('uses custom request properties to log additional attributes when provided'
     }
   }
   var logger = pinoHttp({
-    reqCustomProps: customPropsHandler
+    customProps: customPropsHandler
   }, dest)
 
   setup(t, logger, function (err, server) {
@@ -788,7 +788,7 @@ test('uses custom request properties to log additional attributes when provided'
 test('uses custom request properties to log additional attributes; custom props is an object instead of callback', function (t) {
   var dest = split(JSON.parse)
   var logger = pinoHttp({
-    reqCustomProps: { key1: 'value1' }
+    customProps: { key1: 'value1' }
   }, dest)
 
   setup(t, logger, function (err, server) {
@@ -805,7 +805,7 @@ test('uses custom request properties to log additional attributes; custom props 
 test('dont pass custom request properties to log additional attributes', function (t) {
   var dest = split(JSON.parse)
   var logger = pinoHttp({
-    reqCustomProps: undefined
+    customProps: undefined
   }, dest)
 
   setup(t, logger, function (err, server) {


### PR DESCRIPTION
Since the function's name no longer accurately represents its new signature, whenever there are other breaking changes to be made to the interface, this would be a good semantic change to also include.