### PR TITLE
Feat/log on closed connections

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -65,15 +65,20 @@ function pinoLogger (opts, stream) {
 
   function onResFinished (err) {
     this.removeListener('error', onResFinished)
+<<<<<<< Updated upstream
+=======
+    this.removeListener('finish', onResFinished)
+>>>>>>> Stashed changes
     this.removeListener('close', onResFinished)
 
     var log = this.log
+    var requestLogged = !!this.requestLogged
     var responseTime = Date.now() - this[startTime]
     var level = customLogLevel ? customLogLevel(this, err) : useLevel
 
     if (err || this.err || this.statusCode >= 500) {
       var error = err || this.err || new Error('failed with status code ' + this.statusCode)
-
+      requestLogged = true
       log[level]({
         [resKey]: this,
         [errKey]: error,
@@ -86,6 +91,14 @@ function pinoLogger (opts, stream) {
       return
     }
 
+<<<<<<< Updated upstream
+=======
+    if (requestLogged) {
+      return
+    }
+
+    requestLogged = true
+>>>>>>> Stashed changes
     log[level]({
       [resKey]: this,
       [responseTimeKey]: responseTime,
@@ -128,6 +141,7 @@ function pinoLogger (opts, stream) {
       }
 
       if (shouldLogSuccess) {
+        res.on('finish', onResFinished)
         res.on('close', onResFinished)
       }
 


### PR DESCRIPTION
This PR fixes the git oops in #117 authored by @dalexanco 

Minor change:
I decided not to attach/detach a listener for the `finish` event when we don't plan on logging it. This shouldn't leave any dangling handlers or change the intended behavior.

Tests pass.
