### PR TITLE
Fix README documentation typo for stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ $ node example.js | pino-pretty
 * `customAttributeKeys`: allows the log object attributes added by `pino-http` to be given custom keys. Accepts an object of format `{ [original]: [override] }`. Attributes available for override are `req`, `res`, `err`, and `responseTime`.
 * `wrapSerializers`: when `false`, custom serializers will be passed the raw value directly. Defaults to `true`.
 * `customProps`: set to a `function (req,res) => { /* returns on object */ }` or `{ /* returns on object */ }` This function will be invoked for each request with `req` and `res` where we could pass additional properties that needs to be logged outside the `req`.
+
 `stream`: the destination stream. Could be passed in as an option too.
 
 #### Examples


### PR DESCRIPTION
A missing newline made the stream documentation part of the last
bullet in the above bullet list.

Before fix:
![before](https://user-images.githubusercontent.com/1945123/114823947-7959a100-9dc4-11eb-8246-cd33cbd25af7.png)

After fix:
![after](https://user-images.githubusercontent.com/1945123/114823989-88405380-9dc4-11eb-866b-9b983e484e97.png)

