### PR TITLE
fixed customProps to capture response object

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -74,7 +74,11 @@ function pinoLogger (opts, stream) {
     var responseTime = Date.now() - this[startTime]
     var level = customLogLevel ? customLogLevel(this, err) : useLevel
 
-    log = (typeof customProps === 'function') ? log.child(customProps(this[reqObject], this)) : log.child(customProps)
+    var req = this.log[reqObject]
+    var res = this
+
+    var customPropBindings = (typeof customProps === 'function') ? customProps(req, res) : customProps
+    log = log.child(customPropBindings)
 
     if (err || this.err || this.statusCode >= 500) {
       var error = err || this.err || new Error('failed with status code ' + this.statusCode)

--- a/logger.js
+++ b/logger.js
@@ -109,7 +109,7 @@ function pinoLogger (opts, stream) {
     req.log = quietReqLogger ? log : fullReqLogger
 
     res[startTime] = res[startTime] || Date.now()
-    //carry request to be executed when response is finished
+    // carry request to be executed when response is finished
     res[reqObject] = req
 
     if (autoLogging) {

--- a/test.js
+++ b/test.js
@@ -839,6 +839,32 @@ test('uses old custom request properties interface to log additional attributes'
   })
 })
 
+test('uses custom request properties to log additional attributes when response provided', function (t) {
+  var dest = split(JSON.parse)
+  function customPropsHandler (req, res) {
+    if (req && res) {
+      return {
+        key1: 'value1',
+        key2: res.statusCode
+      }
+    }
+  }
+  var logger = pinoHttp({
+    reqCustomProps: customPropsHandler
+  }, dest)
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server, ERROR_URL)
+  })
+
+  dest.on('data', function (line) {
+    t.equal(line.key1, 'value1')
+    t.equal(line.key2, 500)
+    t.end()
+  })
+})
+
 test('uses custom request properties to log additional attributes; custom props is an object instead of callback', function (t) {
   var dest = split(JSON.parse)
   var logger = pinoHttp({


### PR DESCRIPTION
I try to use `customProps` to return `res.statusCode` in top-level with `nestjs-pino` but found statusCode is incorrect.
so I add below testcase to ensure not related to nest dependencies.

```
test('uses custom request properties to log additional attributes when response provided', function (t) {
  var dest = split(JSON.parse)
  function customPropsHandler (req, res) {
    if (req && res) {
      return {
        key1: 'value1',
        key2: res.statusCode
      }
    }
  }
  var logger = pinoHttp({
    reqCustomProps: customPropsHandler
  }, dest)

  setup(t, logger, function (err, server) {
    t.error(err)
    doGet(server, ERROR_URL)
  })

  dest.on('data', function (line) {
    t.equal(line.key1, 'value1')
    t.equal(line.key2, 500)
    t.end()
  })
})
```
so this fixed is correct `response` object to be pass through `customProps` option.

NOTE: not sure `Destructuring assignment` is available on this repo or not, please advise.
