### PR TITLE
Export Options from index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ interface HttpLogger {
 }
 type ReqId = number | string | object;
 
-interface Options extends pino.LoggerOptions {
+export interface Options extends pino.LoggerOptions {
     logger?: pino.Logger | undefined;
     genReqId?: GenReqId | undefined;
     useLevel?: pino.Level | undefined;


### PR DESCRIPTION
Exporting the Options interface makes writing TS code that uses pino-http much easier. Especially because the "first parameter" type can't be directly inferred to a TS `type` due to overloads.