### PR TITLE
Add back pino-related typings on IncomingMessage, OutgoingMessage and…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-// Type definitions for pino-http 6.x
 // Project: https://github.com/pinojs/pino-http#readme
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
 //                 Jeremy Forsythe <https://github.com/jdforsythe>

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for pino-http 6.0
+// Type definitions for pino-http 6.x
 // Project: https://github.com/pinojs/pino-http#readme
 // Definitions by: Christian Rackerseder <https://github.com/screendriver>
 //                 Jeremy Forsythe <https://github.com/jdforsythe>
@@ -67,3 +67,19 @@ export default pinoHttp;
 export const startTime: unique symbol;
 
 export const stdSerializers: StdSerializers;
+
+declare module "http" {
+    interface IncomingMessage {
+      id: ReqId;
+      log: pino.Logger;
+    }
+  
+    interface ServerResponse {
+      err?: Error | undefined;
+    }
+  
+    interface OutgoingMessage {
+      [startTime]: number;
+    }
+  }
+  

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -5,7 +5,8 @@ import { Writable } from 'stream';
 import { IncomingMessage, ServerResponse } from 'http';
 import { Socket } from 'net';
 import pino from 'pino';
-import pinoHttp, { HttpLogger, ReqId, Options, GenReqId, AutoLoggingOptions, CustomAttributeKeys, StdSerializers } from './';
+import pinoHttp, { HttpLogger, ReqId, Options, GenReqId, AutoLoggingOptions, CustomAttributeKeys, StdSerializers, startTime } from './';
+import { RequestListener } from 'http';
 
 const logger = pino();
 
@@ -143,4 +144,12 @@ const stdSerializers: StdSerializers = {
     headers: { header: 'header' },
     raw: new ServerResponse(new IncomingMessage(new Socket())),
   },
+};
+
+const httpServerListener: RequestListener = (request, response) => {
+  // req.log and req.id should be available
+  request.log.info(`Request received with request ID ${request.id}`);
+  // res[startTime] should be available
+  response[startTime] = Date.now();
+  response.end("Hello world");
 };

--- a/test/test.js
+++ b/test/test.js
@@ -90,7 +90,7 @@ test('add transport.caller information when missing', function (t) {
   const options = {
     transport: {
       targets: [
-        { target: 'pino/file', options: { destination: '/dev/null' } }
+        { target: 'pino/file', options: { destination: (process.platform !== 'win32') ? '/dev/null' : undefined } }
       ]
     }
   }


### PR DESCRIPTION
… ServerResponse.

Also fixed a test that fails on Windows (no /dev/null available, will print to STDOUT instead).

Ref. #175.
These additional typings are included in the @types/pino-http, so I just added them back in.