### PR TITLE
Early return on silent level

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ node example.js | pino-pretty
 * `logger`: parent pino instance for a child logger instance, which will be used by `pino-http`. To refer to this child instance, use [pinoHttp.logger](#pinohttplogger-plogger)
 * `genReqId`: you can pass a function which gets used to generate a request id. The first argument is the request itself. As fallback `pino-http` is just using an integer. This default might not be the desired behavior if you're running multiple instances of the app
 * `useLevel`: the logger level `pino-http` is using to log out the response. default: `info`
-* `customLogLevel`: set to a `function (res, err, req) => { /* returns level name string */ }`. This function will be invoked to determine the level at which the log should be issued. This option is mutually exclusive with the `useLevel` option. The first argument is the HTTP response. The second argument is an error object if an error has occurred in the request.
+* `customLogLevel`: set to a `function (res, err, req) => { /* returns level name string */ }`. This function will be invoked to determine the level at which the log should be issued (`silent` will prevent logging). This option is mutually exclusive with the `useLevel` option. The first argument is the HTTP response. The second argument is an error object if an error has occurred in the request.
 * `autoLogging`: set to `false`, to disable the automatic "request completed" and "request errored" logging. Defaults to `true`. If set to an object, you can provide more options.
 * `autoLogging.ignore`: set to a `function (req) => { /* returns boolean */ }`. Useful for defining logic based on req properties (such as a user-agent header) to ignore successful requests.
 * `autoLogging.ignorePaths`: array that holds one or many paths that should not autolog on completion. Paths will be matched exactly to the url path `req.url` (using Node class `URL.pathname`). This is useful for ignoring e.g. health check paths that get called every X seconds, and would fill out the logs unnecessarily. If the path matches and succeeds (http 200), it will not log any text. If it fails, it will log the error (as with any other path).
@@ -148,6 +148,8 @@ const logger = require('pino-http')({
       return 'warn'
     } else if (res.statusCode >= 500 || err) {
       return 'error'
+    } else if (res.statusCode >= 300 && res.statusCode < 400) {
+      return 'silent'
     }
     return 'info'
   },

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,10 +25,10 @@ export type ReqId = number | string | object;
 export interface Options extends pino.LoggerOptions {
     logger?: pino.Logger | undefined;
     genReqId?: GenReqId | undefined;
-    useLevel?: pino.Level | undefined;
+    useLevel?: pino.LevelWithSilent | undefined;
     stream?: pino.DestinationStream | undefined;
     autoLogging?: boolean | AutoLoggingOptions | undefined;
-    customLogLevel?: ((res: ServerResponse, error: Error) => pino.Level) | undefined;
+    customLogLevel?: ((res: ServerResponse, error: Error) => pino.LevelWithSilent) | undefined;
     customReceivedMessage?: ((req: IncomingMessage, res: ServerResponse) => string) | undefined;
     customSuccessMessage?: ((res: ServerResponse) => string) | undefined;
     customErrorMessage?: ((error: Error, res: ServerResponse) => string) | undefined;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -55,7 +55,7 @@ const rtnBool = () => {
 }
 
 const rtnLevel = () => {
-  let rtn: pino.Level = 'debug';
+  let rtn: pino.LevelWithSilent = 'debug';
   if (rand()) {
     rtn = 'error';
   } else if (rand()) {
@@ -66,6 +66,8 @@ const rtnLevel = () => {
     rtn = 'trace';
   } else if (rand()) {
     rtn = 'warn';
+  } else if (rand()) {
+    rtn = 'silent';
   }
   return rtn;
 }

--- a/logger.js
+++ b/logger.js
@@ -90,6 +90,10 @@ function pinoLogger (opts, stream) {
     const responseTime = Date.now() - this[startTime]
     const level = getLogLevelFromCustomLogLevel(customLogLevel, useLevel, this, err)
 
+    if (level === 'silent') {
+      return
+    }
+
     if (err || this.err || this.statusCode >= 500) {
       const error = err || this.err || new Error('failed with status code ' + this.statusCode)
 

--- a/test/test.js
+++ b/test/test.js
@@ -151,6 +151,32 @@ test('uses the custom log level passed in as an option', function (t) {
   })
 })
 
+test('no autoLogging if useLevel or customLogLevel is silent', function (t) {
+  const dest = split(JSON.parse)
+  const logger = pinoHttp(
+    {
+      customLogLevel: function (_res, _err, _req) {
+        return 'silent'
+      }
+    },
+    dest
+  )
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server)
+  })
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server, null, function () {
+      const line = dest.read()
+      t.equal(line, null)
+      t.end()
+    })
+  })
+})
+
 test('uses the custom invalid log level passed in as an option', function (t) {
   const dest = split(JSON.parse)
   const logger = pinoHttp({


### PR DESCRIPTION
### Description

This PR begin from a specific need:
 - Love autoLogging
 - Love serializers
 - Doesn't need health check logs
 - Only needs logs for debug
 - `Can I prevent autoLogging by Response status code?` **NO**
 
I just add an early return in the `onResFinished` method. When the `level`, coming either from `useLevel` or `customLogLevel` option, the method finishes early without calling the logger.


This PR doesn't have breaking changes.

### Related Issue

resolve #190 