### PR TITLE
25% throughput improvement

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -22,7 +22,7 @@ function pinoLogger (opts, stream) {
   const responseTimeKey = opts.customAttributeKeys.responseTime || 'responseTime'
   delete opts.customAttributeKeys
 
-  const customProps = opts.customProps || opts.reqCustomProps || {}
+  const customProps = opts.customProps || opts.reqCustomProps || undefined
 
   opts.wrapSerializers = 'wrapSerializers' in opts ? opts.wrapSerializers : true
   if (opts.wrapSerializers) {
@@ -120,7 +120,9 @@ function pinoLogger (opts, stream) {
 
     let fullReqLogger = log.child({ [reqKey]: req })
     const customPropBindings = (typeof customProps === 'function') ? customProps(req, res) : customProps
-    fullReqLogger = fullReqLogger.child(customPropBindings)
+    if (customPropBindings) {
+      fullReqLogger = fullReqLogger.child(customPropBindings)
+    }
 
     res.log = fullReqLogger
     req.log = quietReqLogger ? log : fullReqLogger


### PR DESCRIPTION
Improve the throughput of express by 25% with this simple change.
There is likely more to be done here to improve things.

Before:

```
$ autocannon -W [ -c 10 -d 2 ] -c 100 -p 10 -d 10 localhost:3000
Running 2s warmup @ http://localhost:3000
10 connections with 10 pipelining factor

Running 10s test @ http://localhost:3000
100 connections with 10 pipelining factor

┌─────────┬────────┬────────┬────────┬────────┬──────────┬──────────┬────────┐
│ Stat    │ 2.5%   │ 50%    │ 97.5%  │ 99%    │ Avg      │ Stdev    │ Max    │
├─────────┼────────┼────────┼────────┼────────┼──────────┼──────────┼────────┤
│ Latency │ 137 ms │ 143 ms │ 169 ms │ 178 ms │ 145.8 ms │ 14.37 ms │ 293 ms │
└─────────┴────────┴────────┴────────┴────────┴──────────┴──────────┴────────┘
┌───────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg     │ Stdev   │ Min     │
├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Req/Sec   │ 5987    │ 5987    │ 6871    │ 7011    │ 6794.73 │ 265.28  │ 5987    │
├───────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ Bytes/Sec │ 1.43 MB │ 1.43 MB │ 1.64 MB │ 1.67 MB │ 1.62 MB │ 63.1 kB │ 1.42 MB │
└───────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┴─────────┘

Req/Bytes counts sampled once per second.

76k requests in 11.02s, 17.8 MB read
```

After:

```
$ autocannon -W [ -c 10 -d 2 ] -c 100 -p 10 -d 10 localhost:3000
Running 2s warmup @ http://localhost:3000
10 connections with 10 pipelining factor

Running 10s test @ http://localhost:3000
100 connections with 10 pipelining factor

┌─────────┬────────┬────────┬────────┬────────┬───────────┬─────────┬────────┐
│ Stat    │ 2.5%   │ 50%    │ 97.5%  │ 99%    │ Avg       │ Stdev   │ Max    │
├─────────┼────────┼────────┼────────┼────────┼───────────┼─────────┼────────┤
│ Latency │ 107 ms │ 110 ms │ 141 ms │ 147 ms │ 114.23 ms │ 12.2 ms │ 241 ms │
└─────────┴────────┴────────┴────────┴────────┴───────────┴─────────┴────────┘
┌───────────┬────────┬────────┬─────────┬─────────┬─────────┬────────┬─────────┐
│ Stat      │ 1%     │ 2.5%   │ 50%     │ 97.5%   │ Avg     │ Stdev  │ Min     │
├───────────┼────────┼────────┼─────────┼─────────┼─────────┼────────┼─────────┤
│ Req/Sec   │ 7543   │ 7543   │ 8727    │ 8919    │ 8664.21 │ 382.04 │ 7541    │
├───────────┼────────┼────────┼─────────┼─────────┼─────────┼────────┼─────────┤
│ Bytes/Sec │ 1.8 MB │ 1.8 MB │ 2.08 MB │ 2.12 MB │ 2.06 MB │ 91 kB  │ 1.79 MB │
└───────────┴────────┴────────┴─────────┴─────────┴─────────┴────────┴─────────┘

Req/Bytes counts sampled once per second.

88k requests in 10.02s, 20.6 MB read
```

Code:

```js
'use strict'

const app = require('express')()

const pino = require('pino')
const dest = pino.destination({ sync: false, dest: '/tmp/test.log' })
const logger = pino(dest)

function main() {
  app.use(require('express-pino-logger')({ logger }))

  app.get('/', function (req, res) {
    res.send('hello world')
  })

  return app.listen(3000)
}

if (require.main === module) {
  main()
} else {
  module.exports = main
}
```