### PR TITLE
Give customProps access to the response

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -86,7 +86,7 @@ function pinoLogger (opts, stream) {
     this.removeListener('error', onResFinished)
     this.removeListener('finish', onResFinished)
 
-    const log = this.log
+    const { log, customPropsFunc } = this.log
     const responseTime = Date.now() - this[startTime]
     const level = getLogLevelFromCustomLogLevel(customLogLevel, useLevel, this, err)
 
@@ -98,14 +98,16 @@ function pinoLogger (opts, stream) {
       const error = err || this.err || new Error('failed with status code ' + this.statusCode)
 
       log[level]({
+        ... customPropsFunc(this),
         [resKey]: this,
         [errKey]: error,
-        [responseTimeKey]: responseTime
+        [responseTimeKey]: responseTime,
       }, errorMessage(error, this))
       return
     }
 
     log[level]({
+      ... customPropsFunc(this),
       [resKey]: this,
       [responseTimeKey]: responseTime
     }, successMessage(this))
@@ -124,7 +126,7 @@ function pinoLogger (opts, stream) {
       fullReqLogger = fullReqLogger.child(customPropBindings)
     }
 
-    res.log = fullReqLogger
+    res.log = { log: fullReqLogger, customPropsFunc : customPropsFactory(customProps)(req)} 
     req.log = quietReqLogger ? log : fullReqLogger
 
     res[startTime] = res[startTime] || Date.now()
@@ -201,6 +203,10 @@ function reqIdGenFactory (func) {
   return function genReqId (req) {
     return req.id || (nextReqId = (nextReqId + 1) & maxInt)
   }
+}
+
+function customPropsFactory(func) {
+  return (req) => ((res) => (typeof func !== 'function') ? func : func(req,res))
 }
 
 module.exports = pinoLogger

--- a/logger.js
+++ b/logger.js
@@ -95,7 +95,11 @@ function pinoLogger (opts, stream) {
       return
     }
 
-    log = (typeof customProps === 'function') ? log.child(customProps(this[reqObject], this)) : log.child(customProps)
+    var req = this.log[reqObject]
+    var res = this
+
+    var customPropBindings = (typeof customProps === 'function') ? customProps(req, res) : customProps
+    log = log.child(customPropBindings)
 
     if (err || this.err || this.statusCode >= 500) {
       const error = err || this.err || new Error('failed with status code ' + this.statusCode)

--- a/logger.js
+++ b/logger.js
@@ -124,7 +124,9 @@ function pinoLogger (opts, stream) {
 
     const log = quietReqLogger ? logger.child({ [requestIdKey]: req.id }) : logger
 
-    const fullReqLogger = log.child({ [reqKey]: req })
+    let fullReqLogger = log.child({ [reqKey]: req })
+    const customPropBindings = (typeof customProps === 'function') ? customProps(req, res) : customProps
+    fullReqLogger = fullReqLogger.child(customPropBindings)
 
     res.log = fullReqLogger
     req.log = quietReqLogger ? log : fullReqLogger
@@ -161,7 +163,7 @@ function pinoLogger (opts, stream) {
       if (shouldLogSuccess) {
         if (receivedMessage !== undefined) {
           const level = getLogLevelFromCustomLogLevel(customLogLevel, useLevel, res, undefined, req)
-          log[level]({}, receivedMessage(req, res))
+          req.log[level](receivedMessage(req, res))
         }
 
         res.on('finish', onResFinished)

--- a/logger.js
+++ b/logger.js
@@ -23,7 +23,7 @@ function pinoLogger (opts, stream) {
   const responseTimeKey = opts.customAttributeKeys.responseTime || 'responseTime'
   delete opts.customAttributeKeys
 
-  const customProps = opts.customProps || opts.reqCustomProps || {}
+  const customProps = opts.customProps || opts.reqCustomProps || undefined
 
   opts.wrapSerializers = 'wrapSerializers' in opts ? opts.wrapSerializers : true
   if (opts.wrapSerializers) {
@@ -87,6 +87,7 @@ function pinoLogger (opts, stream) {
     this.removeListener('error', onResFinished)
     this.removeListener('finish', onResFinished)
 
+    let log = this.log
     const responseTime = Date.now() - this[startTime]
     const level = getLogLevelFromCustomLogLevel(customLogLevel, useLevel, this, err)
 
@@ -98,7 +99,9 @@ function pinoLogger (opts, stream) {
     const res = this
 
     const customPropBindings = (typeof customProps === 'function') ? customProps(req, res) : customProps
-    const log = this.log.child(customPropBindings)
+    if (customPropBindings) {
+      log = this.log.child(customPropBindings)
+    }
 
     if (err || this.err || this.statusCode >= 500) {
       const error = err || this.err || new Error('failed with status code ' + this.statusCode)
@@ -126,7 +129,9 @@ function pinoLogger (opts, stream) {
 
     let fullReqLogger = log.child({ [reqKey]: req })
     const customPropBindings = (typeof customProps === 'function') ? customProps(req, res) : customProps
-    fullReqLogger = fullReqLogger.child(customPropBindings)
+    if (customPropBindings) {
+      fullReqLogger = fullReqLogger.child(customPropBindings)
+    }
 
     res.log = fullReqLogger
     req.log = quietReqLogger ? log : fullReqLogger

--- a/logger.js
+++ b/logger.js
@@ -135,7 +135,7 @@ function pinoLogger (opts, stream) {
     req.log = quietReqLogger ? log : fullReqLogger
 
     res[startTime] = res[startTime] || Date.now()
-    //carry request to be executed when response is finished
+    // carry request to be executed when response is finished
     res[reqObject] = req
 
     if (autoLogging) {

--- a/test/test.js
+++ b/test/test.js
@@ -982,6 +982,32 @@ test('uses old custom request properties interface to log additional attributes'
   })
 })
 
+test('uses custom request properties to log additional attributes when response provided', function (t) {
+  var dest = split(JSON.parse)
+  function customPropsHandler (req, res) {
+    if (req && res) {
+      return {
+        key1: 'value1',
+        key2: res.statusCode
+      }
+    }
+  }
+  var logger = pinoHttp({
+    reqCustomProps: customPropsHandler
+  }, dest)
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server, ERROR_URL)
+  })
+
+  dest.on('data', function (line) {
+    t.equal(line.key1, 'value1')
+    t.equal(line.key2, 500)
+    t.end()
+  })
+})
+
 test('uses custom request properties to log additional attributes; custom props is an object instead of callback', function (t) {
   const dest = split(JSON.parse)
   const logger = pinoHttp({

--- a/test/test.js
+++ b/test/test.js
@@ -1018,7 +1018,7 @@ test('uses custom request properties and a receivedMessage callback and the prop
     reqCustomProps: (req, res) => {
       return {
         key1: 'value1',
-        key2: res?.statusCode
+        key2: res.statusCode
       }
     }
   }, dest)

--- a/test/test.js
+++ b/test/test.js
@@ -983,7 +983,7 @@ test('uses old custom request properties interface to log additional attributes'
 })
 
 test('uses custom request properties to log additional attributes when response provided', function (t) {
-  var dest = split(JSON.parse)
+  const dest = split(JSON.parse)
   function customPropsHandler (req, res) {
     if (req && res) {
       return {
@@ -992,7 +992,7 @@ test('uses custom request properties to log additional attributes when response 
       }
     }
   }
-  var logger = pinoHttp({
+  const logger = pinoHttp({
     reqCustomProps: customPropsHandler
   }, dest)
 


### PR DESCRIPTION
This PR fixes the issues with #168 and also fixes the regression it introduced where customProps wouldn't be set until the response was sent (if you were using customReceiveMessage or just any other logging on your server).

The downsides are the customProps gets called twice, but it feels worth it to me personally.