### PR TITLE
Typescript fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -77,6 +77,7 @@ declare module "http" {
   
     interface ServerResponse {
       err?: Error | undefined;
+      log: pino.Logger;
     }
   
     interface OutgoingMessage {

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,7 +77,7 @@ declare module "http" {
   
     interface ServerResponse {
       err?: Error | undefined;
-      log: pino.Logger;
+      log?: pino.Logger;
     }
   
     interface OutgoingMessage {

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ export interface Options extends pino.LoggerOptions {
     customErrorMessage?: ((error: Error, res: ServerResponse) => string) | undefined;
     customAttributeKeys?: CustomAttributeKeys | undefined;
     wrapSerializers?: boolean | undefined;
-    reqCustomProps?: ((req: IncomingMessage, res: ServerResponse) => object) | undefined;
+    reqCustomProps?: ((req: IncomingMessage, res: ServerResponse) => object | null) | undefined;
     quietReqLogger?: boolean | undefined;
 }
 


### PR DESCRIPTION
Fixes for two problems in typescript definitions

1 - reqCustomProps
The definition of reqCustomProps is `reqCustomProps?: ((req: IncomingMessage, res: ServerResponse) => object) | undefined;`
The [code](https://github.com/pinojs/pino-http/blob/master/logger.js#L132) in logger.js can handle falsey returns.
Allowing null responses would let us to use reqCustomProps and not always create a child logger.
```
  reqCustomProps: (req) => {
    if (req.user) {
      return { userId: req.user.id };
    }
    return null;
  },
```

The above already works in the code, but typescript complains. This change makes typescript happy
```
    reqCustomProps?: ((req: IncomingMessage, res: ServerResponse) => object | null) | undefined;
```


2 - res.log
http.ServerResponse is extended to include .err, but not .log.

The log property is added to res [here](https://github.com/pinojs/pino-http/blob/master/logger.js#L136).
```
    res.log = fullReqLogger
```
This means that, while this works, typescript complains:
```
  if (req.user) {
    const userId = req.user.id;
    if (req.log) {
      req.log = req.log.child({ userId });
    }
    if (res.log) {
      res.log = res.log.child({ userId });
    }
  }
```

Extending http.ServerResponse to include .log makes typescript stop complaining.

```
declare module "http" {
    interface ServerResponse {
      err?: Error | undefined;
      log: pino.Logger;
    }
  }
```
