### PR TITLE
Log requests aborted during payload processing

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -71,7 +71,7 @@ function pinoLogger (opts, stream) {
   delete opts.autoLogging
 
   const receivedMessage = opts.customReceivedMessage && typeof opts.customReceivedMessage === 'function' ? opts.customReceivedMessage : undefined
-  const successMessage = opts.customSuccessMessage || function () { return 'request completed' }
+  const successMessage = opts.customSuccessMessage || function (req, res) { return res.writableEnded ? 'request completed' : 'request aborted' }
   const errorMessage = opts.customErrorMessage || function () { return 'request errored' }
   delete opts.customSuccessfulMessage
   delete opts.customErroredMessage
@@ -84,6 +84,7 @@ function pinoLogger (opts, stream) {
   return loggingMiddleware
 
   function onResFinished (err) {
+    this.removeListener('close', onResFinished)
     this.removeListener('error', onResFinished)
     this.removeListener('finish', onResFinished)
 
@@ -171,6 +172,7 @@ function pinoLogger (opts, stream) {
           req.log[level](receivedMessage(req, res))
         }
 
+        res.on('close', onResFinished)
         res.on('finish', onResFinished)
       }
 

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,8 @@
 
 const test = require('tap').test
 const http = require('http')
+const net = require('net')
+const stream = require('stream')
 const pinoHttp = require('../')
 const pino = require('pino')
 const split = require('split2')
@@ -12,6 +14,7 @@ const noop = function () {}
 
 const DEFAULT_REQUEST_RECEIVED_MSG = 'request received'
 const DEFAULT_REQUEST_COMPLETED_MSG = 'request completed'
+const DEFAULT_REQUEST_ABORTED_MSG = 'request aborted'
 const DEFAULT_REQUEST_ERROR_MSG = 'request errored'
 
 function setup (t, logger, cb, handler, next) {
@@ -350,6 +353,48 @@ test('responseTime for request emitting error event', function (t) {
 
   dest.on('data', function (line) {
     t.ok(line.responseTime >= 0, 'responseTime is defined')
+    t.end()
+  })
+})
+
+test('log requests aborted during payload', function (t) {
+  const dest = split(JSON.parse)
+  const logger = pinoHttp(dest)
+
+  function handle (req, res) {
+    logger(req, res)
+
+    const read = new stream.Readable({
+      read () {
+        if (this.called) {
+          return
+        }
+
+        this.called = true
+        this.push('delayed')
+      }
+    })
+
+    read.pipe(res)
+  }
+
+  function listen (err, server) {
+    t.error(err)
+
+    const client = net.connect(server.address().port, () => {
+      client.write('GET /delayed HTTP/1.1\r\n\r\n')
+    })
+
+    client.on('data', (data) => {
+      client.destroy()
+    })
+  }
+
+  setup(t, logger, listen, handle)
+
+  dest.on('data', function (line) {
+    t.ok(line.responseTime >= 0, 'responseTime is defined')
+    t.equal(line.msg, DEFAULT_REQUEST_ABORTED_MSG, 'message is set')
     t.end()
   })
 })


### PR DESCRIPTION
Client requests aborted during payload processing are now logged as `request aborted` instead of being silently ignored. Continues the work on #117 and #123. Tests do not rely on timers, and are based on hapi's [tests](https://github.com/hapijs/hapi/blob/fd3cea77d8ce0a1d8d2869919ccf6465a14ea977/test/request.js#L437)
