### PR TITLE
Add custom object hooks

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,9 @@ export interface Options extends pino.LoggerOptions {
     customReceivedMessage?: ((req: IncomingMessage, res: ServerResponse) => string) | undefined;
     customSuccessMessage?: ((req: IncomingMessage, res: ServerResponse) => string) | undefined;
     customErrorMessage?: ((req: IncomingMessage, res: ServerResponse, error: Error) => string) | undefined;
+    customReceivedObject?: ((req: IncomingMessage, res: ServerResponse, val?: any) => any) | undefined;
+    customSuccessObject?: ((req: IncomingMessage, res: ServerResponse, val: any) => any) | undefined;
+    customErrorObject?: ((req: IncomingMessage, res: ServerResponse, error: Error, val: any) => string) | undefined;
     customAttributeKeys?: CustomAttributeKeys | undefined;
     wrapSerializers?: boolean | undefined;
     customProps?: ((req: IncomingMessage, res: ServerResponse) => object) | undefined;

--- a/logger.js
+++ b/logger.js
@@ -6,30 +6,6 @@ const getCallerFile = require('get-caller-file')
 const startTime = Symbol('startTime')
 const reqObject = Symbol('reqObject')
 
-function GetFunctionOrDefault (value, defaultValue) {
-  if (value && typeof value === 'function') {
-    return value
-  }
-
-  return defaultValue
-}
-
-function DefaultSuccessfulRequestObjectProvider (req, res, successObject) {
-  return successObject
-}
-
-function DefaultFailedRequestObjectProvider (req, res, error, errorObject) {
-  return errorObject
-}
-
-function DefaultFailedRequestMessageProvider () {
-  return 'request errored'
-}
-
-function DefaultSuccessfulRequestMessageProvider (req, res) {
-  return res.writableEnded ? 'request completed' : 'request aborted'
-}
-
 function pinoLogger (opts, stream) {
   if (opts && opts._writableState) {
     stream = opts
@@ -88,14 +64,14 @@ function pinoLogger (opts, stream) {
   const autoLoggingIgnore = opts.autoLogging && opts.autoLogging.ignore ? opts.autoLogging.ignore : null
   delete opts.autoLogging
 
-  const onRequestReceivedObject = GetFunctionOrDefault(opts.customReceivedObject, undefined)
-  const receivedMessage = GetFunctionOrDefault(opts.customReceivedMessage, undefined)
+  const onRequestReceivedObject = getFunctionOrDefault(opts.customReceivedObject, undefined)
+  const receivedMessage = getFunctionOrDefault(opts.customReceivedMessage, undefined)
 
-  const onRequestSuccessObject = GetFunctionOrDefault(opts.customSuccessObject, DefaultSuccessfulRequestObjectProvider)
-  const successMessage = GetFunctionOrDefault(opts.customSuccessMessage, DefaultSuccessfulRequestMessageProvider)
+  const onRequestSuccessObject = getFunctionOrDefault(opts.customSuccessObject, defaultSuccessfulRequestObjectProvider)
+  const successMessage = getFunctionOrDefault(opts.customSuccessMessage, defaultSuccessfulRequestMessageProvider)
 
-  const onRequestErrorObject = GetFunctionOrDefault(opts.customErrorObject, DefaultFailedRequestObjectProvider)
-  const errorMessage = GetFunctionOrDefault(opts.customErrorMessage, DefaultFailedRequestMessageProvider)
+  const onRequestErrorObject = getFunctionOrDefault(opts.customErrorObject, defaultFailedRequestObjectProvider)
+  const errorMessage = getFunctionOrDefault(opts.customErrorMessage, defaultFailedRequestMessageProvider)
 
   delete opts.customSuccessfulMessage
   delete opts.customErroredMessage
@@ -236,6 +212,30 @@ function reqIdGenFactory (func) {
   return function genReqId (req) {
     return req.id || (nextReqId = (nextReqId + 1) & maxInt)
   }
+}
+
+function getFunctionOrDefault (value, defaultValue) {
+  if (value && typeof value === 'function') {
+    return value
+  }
+
+  return defaultValue
+}
+
+function defaultSuccessfulRequestObjectProvider (req, res, successObject) {
+  return successObject
+}
+
+function defaultFailedRequestObjectProvider (req, res, error, errorObject) {
+  return errorObject
+}
+
+function defaultFailedRequestMessageProvider () {
+  return 'request errored'
+}
+
+function defaultSuccessfulRequestMessageProvider (req, res) {
+  return res.writableEnded ? 'request completed' : 'request aborted'
 }
 
 module.exports = pinoLogger

--- a/test/test.js
+++ b/test/test.js
@@ -829,6 +829,25 @@ test('uses the custom successMessage callback if passed in as an option', functi
   })
 })
 
+test('uses the custom successObject callback if passed in as an option', function (t) {
+  const dest = split(JSON.parse)
+  const logger = pinoHttp({
+    customSuccessObject: function (req, res, val) {
+      return { ...val, label: req.method + ' customSuccessObject' }
+    }
+  }, dest)
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server)
+  })
+
+  dest.on('data', function (line) {
+    t.equal(line.label, 'GET customSuccessObject')
+    t.end()
+  })
+})
+
 test('uses the custom receivedMessage callback if passed in as an option', function (t) {
   const dest = split(JSON.parse)
   const message = DEFAULT_REQUEST_RECEIVED_MSG
@@ -848,6 +867,57 @@ test('uses the custom receivedMessage callback if passed in as an option', funct
       return
     }
     t.equal(line.msg, message)
+    t.end()
+  })
+})
+
+test('uses the custom receivedObject callback if passed in as an option', function (t) {
+  const dest = split(JSON.parse)
+  const logger = pinoHttp({
+    customReceivedObject: function (req, val) {
+      return { label: req.method + ' customReceivedObject' }
+    }
+  }, dest)
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server)
+  })
+
+  dest.on('data', function (line) {
+    if (line.label === undefined) {
+      return
+    }
+
+    t.equal(line.label, 'GET customReceivedObject')
+    t.end()
+  })
+})
+
+test('uses the custom receivedObject + receivedMessage callback if passed in as an option', function (t) {
+  const dest = split(JSON.parse)
+  const logger = pinoHttp({
+    customReceivedMessage: function (_req, _res) {
+      return DEFAULT_REQUEST_RECEIVED_MSG
+    },
+
+    customReceivedObject: function (req, val) {
+      return { label: req.method + ' customReceivedObject' }
+    }
+  }, dest)
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server)
+  })
+
+  dest.on('data', function (line) {
+    if (line.label === undefined && line.msg !== undefined) {
+      return
+    }
+
+    t.equal(line.msg, DEFAULT_REQUEST_RECEIVED_MSG)
+    t.equal(line.label, 'GET customReceivedObject')
     t.end()
   })
 })
@@ -890,6 +960,25 @@ test('uses the custom errorMessage callback if passed in as an option', function
 
   dest.on('data', function (line) {
     t.equal(line.msg.indexOf(customErrorMessage + ' GET'), 0)
+    t.end()
+  })
+})
+
+test('uses the custom errorObject callback if passed in as an option', function (t) {
+  const dest = split(JSON.parse)
+  const logger = pinoHttp({
+    customErrorObject: function (req, res, err, val) {
+      return { ...val, label: 'customErrorObject ' + req.method + ' ' + err.toString() }
+    }
+  }, dest)
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server, ERROR_URL)
+  })
+
+  dest.on('data', function (line) {
+    t.equal(line.label.indexOf('customErrorObject GET'), 0)
     t.end()
   })
 })


### PR DESCRIPTION
This adds a functionality for overriding/customising the structured object logged at request received/success/error. It is *like* the custom[Received|Success|Error]Message hooks, but works on customising the structured object.

It was opted not to overload *Message due to that being specifically about messages, and the risk that adjusting that could break an existing usage of that hook.

The README has been updated with example usage.