### PR TITLE
refactor(logger): remove uneeded defensive code

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -155,7 +155,7 @@ function pinoLogger (opts, stream) {
 
     if (autoLogging) {
       if (autoLoggingIgnore !== null && shouldLogSuccess === true) {
-        const isIgnored = autoLoggingIgnore !== null && autoLoggingIgnore(req)
+        const isIgnored = autoLoggingIgnore(req)
         shouldLogSuccess = !isIgnored
       }
 


### PR DESCRIPTION
`autoLoggingIgnore` is already checked to not be null on the line above:

https://github.com/pinojs/pino-http/blob/5d8a2f5a57c7ce52e4170ecf0e8d41e5b9fadb38/logger.js#L157