### PR TITLE
Pass response object to genReqId()

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,21 @@ $ node example.js | pino-pretty
 
 const http = require('http')
 const server = http.createServer(handle)
+const { v4: uuidv4 } = require('uuid')
 const pino = require('pino')
 const logger = require('pino-http')({
   // Reuse an existing logger instance
   logger: pino(),
 
   // Define a custom request id function
-  genReqId: function (req) { return req.id },
+  genReqId: function (req, res) {
+    if (req.id) return req.id
+    let id = req.get('X-Request-Id')
+    if (id) return id
+    id = uuidv4()
+    res.header('X-Request-Id', id)
+    return id
+  },
 
   // Define custom serializers
   serializers: {

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ $ node example.js | pino-pretty
 
 const http = require('http')
 const server = http.createServer(handle)
-const { v4: uuidv4 } = require('uuid')
+const { randomUUID } = require('node:crypto')
 const pino = require('pino')
 const logger = require('pino-http')({
   // Reuse an existing logger instance
@@ -133,7 +133,7 @@ const logger = require('pino-http')({
     if (req.id) return req.id
     let id = req.get('X-Request-Id')
     if (id) return id
-    id = uuidv4()
+    id = randomUUID()
     res.header('X-Request-Id', id)
     return id
   },

--- a/logger.js
+++ b/logger.js
@@ -136,7 +136,7 @@ function pinoLogger (opts, stream) {
   function loggingMiddleware (req, res, next) {
     let shouldLogSuccess = true
 
-    req.id = genReqId(req)
+    req.id = genReqId(req, res)
 
     const log = quietReqLogger ? logger.child({ [requestIdKey]: req.id }) : logger
 
@@ -209,7 +209,7 @@ function reqIdGenFactory (func) {
   if (typeof func === 'function') return func
   const maxInt = 2147483647
   let nextReqId = 0
-  return function genReqId (req) {
+  return function genReqId (req, res) {
     return req.id || (nextReqId = (nextReqId + 1) & maxInt)
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -290,7 +290,7 @@ test('uses a custom genReqId function', function (t) {
 
   const dest = split(JSON.parse)
   let idToTest
-  function genReqId (req) {
+  function genReqId (req, res) {
     t.ok(req.url, 'The first argument must be the request parameter')
     idToTest = (Date.now() + Math.random()).toString(32)
     return idToTest
@@ -536,7 +536,7 @@ test('support a custom instance with custom genReqId function', function (t) {
   const dest = split(JSON.parse)
 
   let idToTest
-  function genReqId (req) {
+  function genReqId (req, res) {
     t.ok(req.url, 'The first argument must be the request parameter')
     idToTest = (Date.now() + Math.random()).toString(32)
     return idToTest

--- a/test/test.js
+++ b/test/test.js
@@ -286,11 +286,12 @@ test('allocate a unique id to every request', function (t) {
 })
 
 test('uses a custom genReqId function', function (t) {
-  t.plan(4)
+  t.plan(5)
 
   const dest = split(JSON.parse)
   let idToTest
   function genReqId (req, res) {
+    t.ok(res, 'res is defined')
     t.ok(req.url, 'The first argument must be the request parameter')
     idToTest = (Date.now() + Math.random()).toString(32)
     return idToTest
@@ -537,6 +538,7 @@ test('support a custom instance with custom genReqId function', function (t) {
 
   let idToTest
   function genReqId (req, res) {
+    t.ok(res, 'res is defined')
     t.ok(req.url, 'The first argument must be the request parameter')
     idToTest = (Date.now() + Math.random()).toString(32)
     return idToTest


### PR DESCRIPTION
Passing the response body object to genReqId() allows us to more easily
share the request ID throughout our code, e.g. setting an “X-Request-Id”
header via “response.header()” or storing it in “response.locals” for
rendering.