### PR TITLE
feat: add option `quietResLogger` to supress response data from res.log entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ $ node example.js | pino-pretty
 * `wrapSerializers`: when `false`, custom serializers will be passed the raw value directly. Defaults to `true`.
 * `customProps`: set to a `function (req, res) => { /* returns on object */ }` or `{ /* returns on object */ }` This function will be invoked for each request with `req` and `res` where we could pass additional properties that need to be logged outside the `req`.
 * `quietReqLogger`: when `true`, the child logger available on `req.log` will no longer contain the full bindings and will now only have the request id bound at `reqId` (note: the autoLogging messages and the logger available on `res.log` will remain the same except they will also have the additional `reqId` property). default: `false`
+* `quietResLogger`: when `true`, the child logger available on `res.log` will no longer contain the full bindings and will now only have the request id bound at `reqId` (note: the autoLogging messages and the logger available on `req.log` will remain the same except they will also have the additional `reqId` property). default: `false`
 
 `stream`: the destination stream. Could be passed in as an option too.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,7 @@ export interface Options extends pino.LoggerOptions {
     wrapSerializers?: boolean | undefined;
     customProps?: ((req: IncomingMessage, res: ServerResponse) => object) | undefined;
     quietReqLogger?: boolean | undefined;
+    quietResLogger?: boolean | undefined;
 }
 
 export interface GenReqId {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -34,6 +34,7 @@ pinoHttp({ customProps: (req: IncomingMessage, res: ServerResponse) => ({ key1: 
 pinoHttp({ wrapSerializers: false });
 pinoHttp(new Writable());
 pinoHttp({ quietReqLogger: true, customAttributeKeys: { reqId: 'reqId' }});
+pinoHttp({ quietResLogger: true });
 
 const rand = () => {
   let rtn = true;
@@ -117,6 +118,7 @@ const options: Options = {
   wrapSerializers: canBeUndefined(rtnBool()),
   customProps: canBeUndefined((req: IncomingMessage, res: ServerResponse) => ({} as object)),
   quietReqLogger: canBeUndefined(rtnBool()),
+  quietResLogger: canBeUndefined(rtnBool()),
 }
 
 // can't pass 'useLevel' and 'customLogLevel' together


### PR DESCRIPTION
closes #235 

I didn't succeeded on making the `npm t` running with no errors, even in the fresh new cloned repo :thinking: 