### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "logger.js",
   "types": "index.d.ts",
   "dependencies": {
-    "fast-url-parser": "^1.1.3",
     "get-caller-file": "^2.0.5",
     "pino": "^8.0.0",
     "pino-std-serializers": "^6.0.0",


### PR DESCRIPTION
refs #229

fast-url-parser was only used by `autologger.ignorePaths`, which was removed.

~~Note: failing tests are inline with master.~~