### PR TITLE
Feature/disable success log

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ $ node example.js | pino-pretty
 * `wrapSerializers`: when `false`, custom serializers will be passed the raw value directly. Defaults to `true`.
 * `customProps`: set to a `function (req, res) => { /* returns on object */ }` or `{ /* returns on object */ }` This function will be invoked for each request with `req` and `res` where we could pass additional properties that need to be logged outside the `req`.
 * `quietReqLogger`: when `true`, the child logger available on `req.log` will no longer contain the full bindings and will now only have the request id bound at `reqId` (note: the autoLogging messages and the logger available on `res.log` will remain the same except they will also have the additional `reqId` property). default: `false`
+* `quietReqLogger`: when `true`, the child logger available on `req.log` will no longer contain the full bindings and will now only have the request id bound at `reqId` (note: the autoLogging messages and the logger available on `res.log` will remain the same except they will also have the additional `reqId` property). default: `false`
 
 `stream`: the destination stream. Could be passed in as an option too.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ $ node example.js | pino-pretty
 * `wrapSerializers`: when `false`, custom serializers will be passed the raw value directly. Defaults to `true`.
 * `customProps`: set to a `function (req, res) => { /* returns on object */ }` or `{ /* returns on object */ }` This function will be invoked for each request with `req` and `res` where we could pass additional properties that need to be logged outside the `req`.
 * `quietReqLogger`: when `true`, the child logger available on `req.log` will no longer contain the full bindings and will now only have the request id bound at `reqId` (note: the autoLogging messages and the logger available on `res.log` will remain the same except they will also have the additional `reqId` property). default: `false`
-* `logReqSuccess`: when `true`, the logger to log out on request complete logs. When `false` nothing will be logged on request complete. `errors` are logged regardless of this setting 
+* `logReqSuccess`: when `true`, the logger to log out on request complete logs. When `false` nothing will be logged on request complete. `errors` are logged regardless of this setting. default: `true`
 
 `stream`: the destination stream. Could be passed in as an option too.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ $ node example.js | pino-pretty
 * `wrapSerializers`: when `false`, custom serializers will be passed the raw value directly. Defaults to `true`.
 * `customProps`: set to a `function (req, res) => { /* returns on object */ }` or `{ /* returns on object */ }` This function will be invoked for each request with `req` and `res` where we could pass additional properties that need to be logged outside the `req`.
 * `quietReqLogger`: when `true`, the child logger available on `req.log` will no longer contain the full bindings and will now only have the request id bound at `reqId` (note: the autoLogging messages and the logger available on `res.log` will remain the same except they will also have the additional `reqId` property). default: `false`
-* `quietReqLogger`: when `true`, the child logger available on `req.log` will no longer contain the full bindings and will now only have the request id bound at `reqId` (note: the autoLogging messages and the logger available on `res.log` will remain the same except they will also have the additional `reqId` property). default: `false`
+* `logReqSuccess`: when `true`, the logger to log out on request complete logs. When `false` nothing will be logged on request complete. `errors` are logged regardless of this setting 
 
 `stream`: the destination stream. Could be passed in as an option too.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,7 +39,7 @@ export interface Options extends pino.LoggerOptions {
     wrapSerializers?: boolean | undefined;
     customProps?: ((req: IncomingMessage, res: ServerResponse) => object) | undefined;
     quietReqLogger?: boolean | undefined;
-    quietResLogger?: boolean | undefined;
+    logReqSuccess?: boolean | undefined;
     /**
      * @deprecated deprecated but still present in pino.
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,11 @@ export interface Options extends pino.LoggerOptions {
     wrapSerializers?: boolean | undefined;
     customProps?: ((req: IncomingMessage, res: ServerResponse) => object) | undefined;
     quietReqLogger?: boolean | undefined;
+    quietResLogger?: boolean | undefined;
+    /**
+     * @deprecated deprecated but still present in pino.
+     */
+    prettyPrint?: boolean
 }
 
 export interface GenReqId {

--- a/logger.js
+++ b/logger.js
@@ -77,6 +77,7 @@ function pinoLogger (opts, stream) {
   delete opts.customErroredMessage
 
   const quietReqLogger = !!opts.quietReqLogger
+  const quietResLogger = !!opts.quietResLogger
 
   const logger = wrapChild(opts, theStream)
 
@@ -134,7 +135,7 @@ function pinoLogger (opts, stream) {
   }
 
   function loggingMiddleware (req, res, next) {
-    let shouldLogSuccess = true
+    let shouldLogSuccess = !quietResLogger
 
     req.id = genReqId(req, res)
 

--- a/logger.js
+++ b/logger.js
@@ -77,7 +77,7 @@ function pinoLogger (opts, stream) {
   delete opts.customErroredMessage
 
   const quietReqLogger = !!opts.quietReqLogger
-  const quietResLogger = !!opts.quietResLogger
+  const logReqSuccess = !!opts.logReqSuccess
 
   const logger = wrapChild(opts, theStream)
 
@@ -135,7 +135,7 @@ function pinoLogger (opts, stream) {
   }
 
   function loggingMiddleware (req, res, next) {
-    let shouldLogSuccess = !quietResLogger
+    let shouldLogSuccess = logReqSuccess
 
     req.id = genReqId(req, res)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pino-http",
-  "version": "8.2.1",
+  "version": "8.3.0",
   "description": "High-speed HTTP logger for Node.js",
   "main": "logger.js",
   "types": "index.d.ts",

--- a/test/test.js
+++ b/test/test.js
@@ -1339,7 +1339,6 @@ test('quiet response complete logging', function (t) {
       t.ok(quietLine.req)
 
       const responseLine = dest.read()
-      console.log({ responseLine })
       t.notOk(responseLine)
 
       t.end()

--- a/test/test.js
+++ b/test/test.js
@@ -1318,3 +1318,31 @@ test('quiet request logging - custom request id key', function (t) {
     })
   }, handler)
 })
+
+test('quiet response logging', function (t) {
+  const dest = split(JSON.parse)
+  const logger = pinoHttp({ quietResLogger: true }, dest)
+
+  function handler (req, res) {
+    t.pass('called')
+    req.id = 'testId'
+    logger(req, res)
+    req.log.info('quiet message')
+    res.end('hello world')
+  }
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server, null, function () {
+      const quietLine = dest.read()
+      t.equal(quietLine.msg, 'quiet message')
+      t.ok(quietLine.req)
+
+      const responseLine = dest.read()
+      console.log({ responseLine })
+      t.notOk(responseLine)
+
+      t.end()
+    })
+  }, handler)
+})

--- a/test/test.js
+++ b/test/test.js
@@ -1321,7 +1321,7 @@ test('quiet request logging - custom request id key', function (t) {
 
 test('quiet response logging', function (t) {
   const dest = split(JSON.parse)
-  const logger = pinoHttp({ quietResLogger: true }, dest)
+  const logger = pinoHttp({ logReqSuccess: false }, dest)
 
   function handler (req, res) {
     t.pass('called')

--- a/test/test.js
+++ b/test/test.js
@@ -1319,7 +1319,7 @@ test('quiet request logging - custom request id key', function (t) {
   }, handler)
 })
 
-test('quiet response logging', function (t) {
+test('quiet response complete logging', function (t) {
   const dest = split(JSON.parse)
   const logger = pinoHttp({ logReqSuccess: false }, dest)
 


### PR DESCRIPTION
This Pr update the logger to disable the request complete log. 

Use case is our services have a heartbeat route then is hit every n seconds and this means logs get filled with request complete logs.