### PR TITLE
Feature: Allow multiple instances of middleware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     paths-ignore:
         - 'docs/**'

--- a/index.d.ts
+++ b/index.d.ts
@@ -80,6 +80,7 @@ declare module "http" {
     interface IncomingMessage {
       id: ReqId;
       log: pino.Logger;
+      allLogs: pino.Logger[];
     }
 
     interface ServerResponse {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -18,7 +18,6 @@ pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => res.statusCo
 pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => 'foo' });
 pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => Buffer.allocUnsafe(16) });
 pinoHttp({ useLevel: 'error' });
-pinoHttp({ prettyPrint: true }); // deprecated but still present in pino.
 pinoHttp({ transport: { target: 'pino-pretty', options: { colorize: true } } });
 pinoHttp({ autoLogging: false });
 pinoHttp({ autoLogging: { ignore: (req: IncomingMessage) => req.headers['user-agent'] === 'ELB-HealthChecker/2.0' } });

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -18,7 +18,6 @@ pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => res.statusCo
 pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => 'foo' });
 pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => Buffer.allocUnsafe(16) });
 pinoHttp({ useLevel: 'error' });
-pinoHttp({ prettyPrint: true }); // deprecated but still present in pino.
 pinoHttp({ transport: { target: 'pino-pretty', options: { colorize: true } } });
 pinoHttp({ autoLogging: false });
 pinoHttp({ autoLogging: { ignore: (req: IncomingMessage) => req.headers['user-agent'] === 'ELB-HealthChecker/2.0' } });
@@ -157,6 +156,7 @@ const stdSerializedResults: StdSerializedResults = {
 const httpServerListener: RequestListener = (request, response) => {
   // req.log and req.id should be available
   request.log.info(`Request received with request ID ${request.id}`);
+  request.allLogs[0].info("Request Received");
   // res[startTime] should be available
   response[startTime] = Date.now();
   response.end("Hello world");

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -18,6 +18,7 @@ pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => res.statusCo
 pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => 'foo' });
 pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => Buffer.allocUnsafe(16) });
 pinoHttp({ useLevel: 'error' });
+pinoHttp({ prettyPrint: true }); // deprecated but still present in pino.
 pinoHttp({ transport: { target: 'pino-pretty', options: { colorize: true } } });
 pinoHttp({ autoLogging: false });
 pinoHttp({ autoLogging: { ignore: (req: IncomingMessage) => req.headers['user-agent'] === 'ELB-HealthChecker/2.0' } });

--- a/logger.js
+++ b/logger.js
@@ -150,7 +150,9 @@ function pinoLogger (opts, stream) {
     if (!res.log) {
       res.log = responseLogger
     }
-    res.allLogs ??= []
+    if (!res.allLogs) {
+      res.allLogs = []
+    }
     res.allLogs.push(responseLogger)
 
     if (!req.log) {

--- a/logger.js
+++ b/logger.js
@@ -37,7 +37,7 @@ function pinoLogger (opts, stream) {
   delete opts.wrapSerializers
 
   if (opts.useLevel && opts.customLogLevel) {
-    throw new Error("You can't pass 'useLevel' and 'customLogLevel' together")
+    throw new Error('You can\'t pass \'useLevel\' and \'customLogLevel\' together')
   }
 
   function getValidLogLevel (level, defaultValue = 'info') {
@@ -85,58 +85,56 @@ function pinoLogger (opts, stream) {
   delete opts.useLevel
 
   const genReqId = reqIdGenFactory(opts.genReqId)
-  loggingMiddleware.logger = logger
-  return loggingMiddleware
+  const result = (req, res, next) => {
+    return loggingMiddleware(logger, req, res, next)
+  }
+  result.logger = logger
+  return result
 
-  function onResFinished (err) {
-    this.removeListener('close', onResFinished)
-    this.removeListener('error', onResFinished)
-    this.removeListener('finish', onResFinished)
-
-    let log = this.log
-    const responseTime = Date.now() - this[startTime]
-    const level = getLogLevelFromCustomLogLevel(customLogLevel, useLevel, this, err)
+  function onResFinished (res, logger, err) {
+    let log = logger
+    const responseTime = Date.now() - res[startTime]
+    const level = getLogLevelFromCustomLogLevel(customLogLevel, useLevel, res, err)
 
     if (level === 'silent') {
       return
     }
 
-    const req = this[reqObject]
-    const res = this
+    const req = res[reqObject]
 
     const customPropBindings = (typeof customProps === 'function') ? customProps(req, res) : customProps
     if (customPropBindings) {
-      log = this.log.child(customPropBindings)
+      log = logger.child(customPropBindings)
     }
 
-    if (err || this.err || this.statusCode >= 500) {
-      const error = err || this.err || new Error('failed with status code ' + this.statusCode)
+    if (err || res.err || res.statusCode >= 500) {
+      const error = err || res.err || new Error('failed with status code ' + res.statusCode)
 
       log[level](
-        onRequestErrorObject(req, this, error, {
-          [resKey]: this,
+        onRequestErrorObject(req, res, error, {
+          [resKey]: res,
           [errKey]: error,
           [responseTimeKey]: responseTime
         }),
-        errorMessage(req, this, error)
+        errorMessage(req, res, error)
       )
 
       return
     }
 
     log[level](
-      onRequestSuccessObject(req, this, {
-        [resKey]: this,
+      onRequestSuccessObject(req, res, {
+        [resKey]: res,
         [responseTimeKey]: responseTime
       }),
-      successMessage(req, this, responseTime)
+      successMessage(req, res, responseTime)
     )
   }
 
-  function loggingMiddleware (req, res, next) {
+  function loggingMiddleware (logger, req, res, next) {
     let shouldLogSuccess = true
 
-    req.id = genReqId(req, res)
+    req.id = req.id || genReqId(req, res)
 
     const log = quietReqLogger ? logger.child({ [requestIdKey]: req.id }) : logger
 
@@ -146,12 +144,31 @@ function pinoLogger (opts, stream) {
       fullReqLogger = fullReqLogger.child(customPropBindings)
     }
 
-    res.log = fullReqLogger
-    req.log = quietReqLogger ? log : fullReqLogger
+    const responseLogger = fullReqLogger
+    const requestLogger = quietReqLogger ? log : fullReqLogger
+
+    if (!res.log) {
+      res.log = responseLogger
+    }
+    res.allLogs ??= []
+    res.allLogs.push(responseLogger)
+
+    if (!req.log) {
+      req.log = requestLogger
+    }
+    req.allLogs ??= []
+    req.allLogs.push(requestLogger)
 
     res[startTime] = res[startTime] || Date.now()
     // carry request to be executed when response is finished
     res[reqObject] = req
+
+    const onResponseComplete = (err) => {
+      res.removeListener('close', onResponseComplete)
+      res.removeListener('finish', onResponseComplete)
+      res.removeListener('error', onResponseComplete)
+      return onResFinished(res, responseLogger, err)
+    }
 
     if (autoLogging) {
       if (autoLoggingIgnore !== null && shouldLogSuccess === true) {
@@ -167,14 +184,14 @@ function pinoLogger (opts, stream) {
           const receivedObjectResult = onRequestReceivedObject !== undefined ? onRequestReceivedObject(req, res, undefined) : {}
           const receivedStringResult = receivedMessage !== undefined ? receivedMessage(req, res) : undefined
 
-          req.log[level](receivedObjectResult, receivedStringResult)
+          requestLogger[level](receivedObjectResult, receivedStringResult)
         }
 
-        res.on('close', onResFinished)
-        res.on('finish', onResFinished)
+        res.on('close', onResponseComplete)
+        res.on('finish', onResponseComplete)
       }
 
-      res.on('error', onResFinished)
+      res.on('error', onResponseComplete)
     }
 
     if (next) {

--- a/logger.js
+++ b/logger.js
@@ -156,7 +156,9 @@ function pinoLogger (opts, stream) {
     if (!req.log) {
       req.log = requestLogger
     }
-    req.allLogs ??= []
+    if (!req.allLogs) {
+      req.allLogs = []
+    }
     req.allLogs.push(requestLogger)
 
     res[startTime] = res[startTime] || Date.now()

--- a/test/test.js
+++ b/test/test.js
@@ -892,7 +892,7 @@ test('pass responseTime argument to the custom successMessage callback', functio
   })
 
   dest.on('data', function (line) {
-    t.equal(line.msg, customResponseMessage + 0 + ' GET')
+    t.match(line.msg, /Response time is: \d+ GET/)
     t.end()
   })
 })


### PR DESCRIPTION
PR to address Issue #260 

- scope pino loggers to lambda closures instead of function properties
- set request and response log property to first middleware pino logger but capture additional middleware pino loggers in new allLogs request and response property
- unit tests to confirm each middleware redact properties are independent