### PR TITLE
fix: set error param as optional for options.customLogLevel

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ export interface Options extends pino.LoggerOptions {
     useLevel?: pino.LevelWithSilent | undefined;
     stream?: pino.DestinationStream | undefined;
     autoLogging?: boolean | AutoLoggingOptions | undefined;
-    customLogLevel?: ((req: IncomingMessage, res: ServerResponse, error: Error) => pino.LevelWithSilent) | undefined;
+    customLogLevel?: ((req: IncomingMessage, res: ServerResponse, error?: Error) => pino.LevelWithSilent) | undefined;
     customReceivedMessage?: ((req: IncomingMessage, res: ServerResponse) => string) | undefined;
     customSuccessMessage?: ((req: IncomingMessage, res: ServerResponse) => string) | undefined;
     customErrorMessage?: ((req: IncomingMessage, res: ServerResponse, error: Error) => string) | undefined;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -18,7 +18,6 @@ pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => res.statusCo
 pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => 'foo' });
 pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => Buffer.allocUnsafe(16) });
 pinoHttp({ useLevel: 'error' });
-pinoHttp({ prettyPrint: true }); // deprecated but still present in pino.
 pinoHttp({ transport: { target: 'pino-pretty', options: { colorize: true } } });
 pinoHttp({ autoLogging: false });
 pinoHttp({ autoLogging: { ignore: (req: IncomingMessage) => req.headers['user-agent'] === 'ELB-HealthChecker/2.0' } });
@@ -29,7 +28,7 @@ pinoHttp({ customAttributeKeys: { res: 'res' } });
 pinoHttp({ customAttributeKeys: { err: 'err' } });
 pinoHttp({ customAttributeKeys: { responseTime: 'responseTime' } });
 pinoHttp({ customAttributeKeys: { req: 'req', res: 'res', err: 'err', responseTime: 'responseTime' } });
-pinoHttp({ customLogLevel: (req: IncomingMessage, res: ServerResponse, error: Error) => 'info' });
+pinoHttp({ customLogLevel: (req: IncomingMessage, res: ServerResponse, error: Error | undefined) => error ? 'error' : 'info' });
 pinoHttp({ customProps: (req: IncomingMessage, res: ServerResponse) => ({ key1: 'value1', 'x-key-2': 'value2' }) });
 pinoHttp({ wrapSerializers: false });
 pinoHttp(new Writable());
@@ -106,7 +105,7 @@ const options: Options = {
   useLevel: canBeUndefined(rtnLevel()),
   stream: canBeUndefined({ write: (msg: string) => { return } }),
   autoLogging: canBeUndefined(autoLoggingOptions),
-  customLogLevel: canBeUndefined((req: IncomingMessage, res: ServerResponse, error: Error) => rtnLevel()),
+  customLogLevel: canBeUndefined((req: IncomingMessage, res: ServerResponse, _error: Error | undefined) => rtnLevel()),
   customReceivedMessage: canBeUndefined((req, res) => {
     res.setHeader('x-custom-header-123', 'custom-header-value');
     return `Received HTTP ${req.httpVersion} ${req.method}`;


### PR DESCRIPTION
according to API docs the error param in customLogLevel function is optional
but that is not reflected in the typescript definition

> customLogLevel: set to a function (req, res, err) => { /* returns level name string */ }. This function will be invoked to determine the level at which the log should be issued (silent will prevent logging). This option is mutually exclusive with the useLevel option. The first two arguments are the HTTP request and response. **The third argument is an error object if an error has occurred in the request**.