### PR TITLE
Switch request id generator to a random string

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -228,10 +228,18 @@ function wrapChild (opts, stream) {
 
 function reqIdGenFactory (func) {
   if (typeof func === 'function') return func
-  const maxInt = 2147483647
-  let nextReqId = 0
-  return function genReqId (req, res) {
-    return req.id || (nextReqId = (nextReqId + 1) & maxInt)
+  return defaultReqIdGenFactory()
+}
+
+function defaultReqIdGenFactory () {
+  const { randomFillSync } = require('crypto')
+  const buffer = Buffer.alloc(12)
+  let id = randomFillSync(buffer).toString('base64url')
+  let count = 0
+
+  return function genReqId () {
+    if (count++ < 9999) return `${id}-${count}`
+    return `${(id = randomFillSync(buffer).toString('base64url'))}-${(count = 1)}`
   }
 }
 
@@ -268,3 +276,4 @@ module.exports.stdSerializers = {
 module.exports.startTime = startTime
 module.exports.default = pinoLogger
 module.exports.pinoHttp = pinoLogger
+module.exports.defaultReqIdGenFactory = defaultReqIdGenFactory

--- a/test/test.js
+++ b/test/test.js
@@ -355,6 +355,31 @@ test('uses a custom genReqId function', function (t) {
   })
 })
 
+test('default genReqId returns a string, wraps around', function (t) {
+  t.plan(10)
+
+  const genReqId = pinoHttp.defaultReqIdGenFactory()
+  t.equal(typeof genReqId, 'function')
+
+  const first = genReqId()
+  const second = genReqId()
+  t.equal(typeof first, 'string')
+  // 12 bytes -> 16 chars + 2 chars for the '-' and counter
+  t.equal(first.length, 16 + 2)
+  t.equal(first.slice(0, 16), second.slice(0, 16))
+  t.equal(first.slice(17), '1')
+  t.equal(second.slice(17), '2')
+
+  for (let i = 0; i < 9999 - 3; i++) genReqId()
+  const last = genReqId()
+  t.equal(last.slice(0, 16), first.slice(0, 16))
+  t.equal(last.slice(17), '9999')
+
+  const next = genReqId()
+  t.notEqual(next.slice(0, 16), first.slice(0, 16))
+  t.equal(next.slice(17), '1')
+})
+
 test('reuses existing req.id if present', function (t) {
   t.plan(2)
 


### PR DESCRIPTION
### Motivation
The current integer-based request id generation is not unique enough when running multiple processes or serving many requests. This prompted implementors to always configure it. The new string based random id generator should serve as production-ready config.

### Implementation
The id generation uses the concept of https://github.com/mcollina/hyperid but does not introduce any dependencies as the logic is rather simple.

It will generate ids from `UCGtioQAmusXkiWj-1` to `UCGtioQAmusXkiWj-9999`.
Therefore have a length from 18 to 21 characters, where the random prefix is 16 characters.

### Benchmark
With a microbenchmark it turns out 12 bytes and a small counter provided the fastest execution time on all node versions.
Much higher numbers like Number.MAX_SAFE_INTEGER as `count` also resulted in slower computations (twice as slow, but it's probably neglectable anyways).

12 bytes result in 16 characters as prefix, which should provide plenty of uniqueness according to https://alex7kom.github.io/nano-nanoid-cc

```
Benchmarking 1'000'000 operations per run.
---
Benchmark: current genReqId
finished 100 runs (0.2s)
Average per run: 2.0ms
---
Benchmark: crypto.randomUUID
finished 100 runs (7.8s)
Average per run: 78.1ms
---
Benchmark: new genReqId with eight bytes
finished 100 runs (1.8s)
Average per run: 18.2ms
---
Benchmark: new genReqId with twelve bytes (the version in this PR)
finished 100 runs (1.2s)
Average per run: 12.4ms
```