### PR TITLE
Fix customSuccessMessage ts definition

### DIFF
--- a/import.test-d.ts
+++ b/import.test-d.ts
@@ -11,6 +11,11 @@ const { pinoHttp: pinoHttpCjsNamed } = require('.');
 const logger = pino();
 
 expectType<HttpLogger>(pinoHttp({ logger }));
+expectType<HttpLogger>(pinoHttp({
+  customSuccessMessage(req, res, responseTime) {
+    return `${responseTime}`
+  }
+}));
 expectType<HttpLogger>(pinoHttpNamed());
 expectType<HttpLogger>(pinoHttpStar.default());
 expectType<HttpLogger>(pinoHttpStar.pinoHttp());

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,7 +30,7 @@ export interface Options extends pino.LoggerOptions {
     autoLogging?: boolean | AutoLoggingOptions | undefined;
     customLogLevel?: ((req: IncomingMessage, res: ServerResponse, error?: Error) => pino.LevelWithSilent) | undefined;
     customReceivedMessage?: ((req: IncomingMessage, res: ServerResponse) => string) | undefined;
-    customSuccessMessage?: ((req: IncomingMessage, res: ServerResponse) => string) | undefined;
+    customSuccessMessage?: ((req: IncomingMessage, res: ServerResponse, responseTime: number) => string) | undefined;
     customErrorMessage?: ((req: IncomingMessage, res: ServerResponse, error: Error) => string) | undefined;
     customReceivedObject?: ((req: IncomingMessage, res: ServerResponse, val?: any) => any) | undefined;
     customSuccessObject?: ((req: IncomingMessage, res: ServerResponse, val: any) => any) | undefined;


### PR DESCRIPTION
https://github.com/pinojs/pino-http/pull/253 added `responseTime` value to be passed into the `customSuccessMessage` callback but the TS definition file was not updated.