### PR TITLE
Fix customLogLevel usage in onResFinished function

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -94,13 +94,12 @@ function pinoLogger (opts, stream) {
   function onResFinished (res, logger, err) {
     let log = logger
     const responseTime = Date.now() - res[startTime]
-    const level = getLogLevelFromCustomLogLevel(customLogLevel, useLevel, res, err)
+    const req = res[reqObject]
+    const level = getLogLevelFromCustomLogLevel(customLogLevel, useLevel, res, err, req)
 
     if (level === 'silent') {
       return
     }
-
-    const req = res[reqObject]
 
     const customPropBindings = (typeof customProps === 'function') ? customProps(req, res) : customProps
     if (customPropBindings) {

--- a/test/test.js
+++ b/test/test.js
@@ -198,6 +198,26 @@ test('uses the custom log level passed in as an option', function (t) {
   })
 })
 
+test('uses the custom log level passed in as an option, req and res is defined', function (t) {
+  const dest = split(JSON.parse)
+  const logger = pinoHttp({
+    customLogLevel: function (_req, _res, _err) {
+      t.ok(_req, 'req is defined')
+      t.ok(_res, 'res is defined')
+
+      return 'warn'
+    }
+  }, dest)
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server)
+  })
+  dest.on('data', function () {
+    t.end()
+  })
+})
+
 test('uses the log level passed in as an option, where the level is a custom one', function (t) {
   const dest = split(JSON.parse)
   const logger = pinoHttp(


### PR DESCRIPTION
Hi!

I found a bug.
There is a missing `req` argument in `getLogLevelFromCustomLogLevel` function call [at onResFinished](https://github.com/pinojs/pino-http/blob/master/logger.js#L97)

Because of this, I got an error `TypeError: Cannot read properties of undefined (reading 'req')`, when using `customLogLevel` option
