### PR TITLE
docs(readme): fix genReqId() example

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,10 @@ const logger = require('pino-http')({
 
   // Define a custom request id function
   genReqId: function (req, res) {
-    if (req.id) return req.id
-    let id = req.get('X-Request-Id')
-    if (id) return id
+    const existingID = req.id ?? req.headers["x-request-id"]
+    if (existingID) return existingID
     id = randomUUID()
-    res.header('X-Request-Id', id)
+    res.setHeader('X-Request-Id', id)
     return id
   },
 


### PR DESCRIPTION
The example in the docs assumes `expressjs` `req` and `res` arguments, but the types in the library assume vanilla `req` and `res`. There is no mention of minimum required NodeJS version so I assume it's at least 14+, which supports [nullish coalescing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing#browser_compatibility).