### PR TITLE
fix: twice customProps

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const pino = require('pino')
+const { pino, symbols: { stringifySym, chindingsSym } } = require('pino')
 const serializers = require('pino-std-serializers')
 const getCallerFile = require('get-caller-file')
 const startTime = Symbol('startTime')
@@ -103,7 +103,11 @@ function pinoLogger (opts, stream) {
 
     const customPropBindings = (typeof customProps === 'function') ? customProps(req, res) : customProps
     if (customPropBindings) {
-      log = logger.child(customPropBindings)
+      const customPropBindingStr = logger[stringifySym](customPropBindings).replace(/[{}]/g, '')
+      const customPropBindingsStr = logger[chindingsSym]
+      if (!customPropBindingsStr.includes(customPropBindingStr)) {
+        log = logger.child(customPropBindings)
+      }
     }
 
     if (err || res.err || res.statusCode >= 500) {

--- a/test/test.js
+++ b/test/test.js
@@ -1304,7 +1304,7 @@ test('uses custom request properties and once customProps', function (t) {
   })
 
   dest.on('data', function (line) {
-    t.equal(line.match(/key1/gi).length, 1, 'once customProps')
+    t.equal(line.match(/key1/g).length, 1, 'once customProps')
     t.end()
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1285,6 +1285,30 @@ test('uses custom request properties to log additional attributes; custom props 
   })
 })
 
+test('uses custom request properties and once customProps', function (t) {
+  const dest = split()
+
+  function customPropsHandler (req, res) {
+    return {
+      key1: 'value1'
+    }
+  }
+
+  const logger = pinoHttp({
+    customProps: customPropsHandler
+  }, dest)
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server)
+  })
+
+  dest.on('data', function (line) {
+    t.equal(line.match(/key1/gi).length, 1, 'once customProps')
+    t.end()
+  })
+})
+
 test('dont pass custom request properties to log additional attributes', function (t) {
   const dest = split(JSON.parse)
   const logger = pinoHttp({


### PR DESCRIPTION
Hello!
I am the author of [pino-web-hook](https://getpino.io/#/docs/transports?id=pino-slack-webhook).

I am using the NestJS framework, and I wanted to display the `pinoHttp` property, thinking that the main function of `nestjs-pino` is Middleware that connects `pino-http`.
```
    LoggerModule.forRoot({
      pinoHttp: {
        customProps: (req, res) => ({
          context: 'HTTP',
        }),
      },
    }),
```
However, I found the following bug, and also found out that there is an issue https://github.com/pinojs/pino-http/issues/216.
<img width="2471" alt="image" src="https://github.com/pinojs/pino-http/assets/13362880/74418d26-c366-455e-860f-26c63bee65e4">

I tried the following to solve this problem.
1. I tried to use [onchild-function](https://github.com/pinojs/pino/blob/master/docs/api.md#onchild-function), but stopped because the instance given as a parameter was a logger instance that could be known outside of OnChildCallback.
  ```js
+   opts.onChild = (instance) => {
+     // Execute call back code for each newly created child.
+   }
      const logger = wrapChild(opts, theStream)
  ```
2. The second method is the current PR. Additional conditional statements can be written on one line, but for readability, I have declared local variables.

I debugged it with the following modified [example.js](https://github.com/pinojs/pino-http/blob/master/example.js) file.
```js
const logger = require('./')({
  customProps: (req, res) => ({
    context: 'HTTP'
  })
})
```

Thanks