### PR TITLE
Fix tests on Node 20

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -499,7 +499,7 @@ test('log requests aborted during payload', function (t) {
     t.error(err)
 
     const client = net.connect(server.address().port, server.address().address, () => {
-      client.write('GET /delayed HTTP/1.1\r\n\r\n')
+      client.write('GET /delayed HTTP/1.1\r\nHost: localhost\r\n\r\n')
     })
 
     client.on('data', (data) => {


### PR DESCRIPTION
https://github.com/nodejs/node/pull/45597/files#diff-2464899ab38c61dd42654fdb9658c75989cb6883b9c9d76613872a12d3fe2780R1036 introduces a requirement that all incoming requests must have a `Host` header included. This is a breaking change in Node v20 that affects our test suite, and blocks #300. The change in this PR fixes it.