### PR TITLE
fix: Pino options have a generic type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,13 +12,13 @@ import { IncomingMessage, ServerResponse } from 'http';
 import pino from 'pino';
 import { err, req, res, SerializedError, SerializedRequest, SerializedResponse } from 'pino-std-serializers';
 
-declare function PinoHttp<IM = IncomingMessage, SR = ServerResponse>(opts?: Options<IM, SR>, stream?: pino.DestinationStream): HttpLogger<IM, SR>;
+declare function PinoHttp<IM = IncomingMessage, SR = ServerResponse, Opts = Options<IM, SR>>(opts?: Opts, stream?: pino.DestinationStream): HttpLogger<IM, SR, Opts>;
 
 declare function PinoHttp<IM = IncomingMessage, SR = ServerResponse>(stream?: pino.DestinationStream): HttpLogger<IM, SR>;
 
-export interface HttpLogger<IM = IncomingMessage, SR = ServerResponse> {
+export interface HttpLogger<IM = IncomingMessage, SR = ServerResponse, Opts = Options<IM, SR>> {
     (req: IM, res: SR, next?: () => void): void;
-    logger: pino.Logger;
+    logger: pino.Logger<Opts>;
 }
 export type ReqId = number | string | object;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -211,7 +211,5 @@ const httpServerListener: RequestListener = (request, response) => {
 pinoHttp({
     customLevels: {
         bark: 25,
-        z: 90
-    },
-    fhfh: true
+    }
 }).logger.bark("arf arf");

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -205,3 +205,13 @@ const httpServerListener: RequestListener = (request, response) => {
   request.allLogs[0].info("allLogs available on response");
   response.end("Hello world");
 };
+
+// custom levels added in the options should be available
+// on the logger returned by pino-http
+pinoHttp({
+    customLevels: {
+        bark: 25,
+        z: 90
+    },
+    fhfh: true
+}).logger.bark("arf arf");


### PR DESCRIPTION
**Issue**
```
import { pinoHttp } from 'pino-http';

const httpLogger = pinoHttp({
    customLevels: {
        log: 20,
    },
});

const logger = httpLogger.logger;

function f(level: 'warn' | 'info' | 'log', message: string): void {
  logger[level](message);
}

```
This code is correct but currently throws a `ts(7053) : Element implicitly has an 'any' type` because TS can't see the custom level added in the configuration.