### PR TITLE
fix: type variable for Logger

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,13 +12,13 @@ import { IncomingMessage, ServerResponse } from 'http';
 import pino from 'pino';
 import { err, req, res, SerializedError, SerializedRequest, SerializedResponse } from 'pino-std-serializers';
 
-declare function PinoHttp<IM = IncomingMessage, SR = ServerResponse, Opts = Options<IM, SR>>(opts?: Opts, stream?: pino.DestinationStream): HttpLogger<IM, SR, Opts>;
+declare function PinoHttp<IM = IncomingMessage, SR = ServerResponse, CustomLevels extends string = never>(opts?: Options<IM, SR>, stream?: pino.DestinationStream): HttpLogger<IM, SR, CustomLevels>;
 
 declare function PinoHttp<IM = IncomingMessage, SR = ServerResponse>(stream?: pino.DestinationStream): HttpLogger<IM, SR>;
 
-export interface HttpLogger<IM = IncomingMessage, SR = ServerResponse, Opts = Options<IM, SR>> {
+export interface HttpLogger<IM = IncomingMessage, SR = ServerResponse, CustomLevels extends string = never> {
     (req: IM, res: SR, next?: () => void): void;
-    logger: pino.Logger<Opts>;
+    logger: pino.Logger<CustomLevels>;
 }
 export type ReqId = number | string | object;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -208,7 +208,7 @@ const httpServerListener: RequestListener = (request, response) => {
 
 // custom levels added in the options should be available
 // on the logger returned by pino-http
-pinoHttp({
+pinoHttp<IncomingMessage, ServerResponse, 'bark'>({
     customLevels: {
         bark: 25,
     }


### PR DESCRIPTION
the type variable of the logger should be the custom levels type
since a recent change in pino types (https://github.com/pinojs/pino/pull/1858)

fixes #313

cc @UndefinedBehaviour 