### PR TITLE
fix: TypeScript for CustomLevels on parent pino instance

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ import { IncomingMessage, ServerResponse } from 'http';
 import pino from 'pino';
 import { err, req, res, SerializedError, SerializedRequest, SerializedResponse } from 'pino-std-serializers';
 
-declare function PinoHttp<IM = IncomingMessage, SR = ServerResponse, CustomLevels extends string = never>(opts?: Options<IM, SR>, stream?: pino.DestinationStream): HttpLogger<IM, SR, CustomLevels>;
+declare function PinoHttp<IM = IncomingMessage, SR = ServerResponse, CustomLevels extends string = never>(opts?: Options<IM, SR, CustomLevels>, stream?: pino.DestinationStream): HttpLogger<IM, SR, CustomLevels>;
 
 declare function PinoHttp<IM = IncomingMessage, SR = ServerResponse>(stream?: pino.DestinationStream): HttpLogger<IM, SR>;
 
@@ -22,8 +22,8 @@ export interface HttpLogger<IM = IncomingMessage, SR = ServerResponse, CustomLev
 }
 export type ReqId = number | string | object;
 
-export interface Options<IM = IncomingMessage, SR = ServerResponse> extends pino.LoggerOptions {
-    logger?: pino.Logger | undefined;
+export interface Options<IM = IncomingMessage, SR = ServerResponse, CustomLevels extends string = never> extends pino.LoggerOptions {
+    logger?: pino.Logger<CustomLevels> | undefined;
     genReqId?: GenReqId<IM, SR> | undefined;
     useLevel?: pino.LevelWithSilent | undefined;
     stream?: pino.DestinationStream | undefined;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -213,3 +213,14 @@ pinoHttp<IncomingMessage, ServerResponse, 'bark'>({
         bark: 25,
     }
 }).logger.bark("arf arf");
+
+// customLevels in parent pino instance should be not cause
+// TypeScript errors
+const customLogger = pino({
+    customLevels: {
+        bark: 25,
+    }
+});
+pinoHttp({
+  logger: customLogger
+}).logger.bark("arf arf");

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "types": "index.d.ts",
   "dependencies": {
     "get-caller-file": "^2.0.5",
-    "pino": "^8.17.0",
-    "pino-std-serializers": "^6.0.0",
+    "pino": "^8.17.1",
+    "pino-std-serializers": "^6.2.2",
     "process-warning": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
CustomLevels from pino parent instance should be passed through TypeScript variables.

Fixes #317 