### PR TITLE
make typesafe custom level loggers great again

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,13 +12,23 @@ import { IncomingMessage, ServerResponse } from 'http';
 import pino from 'pino';
 import { err, req, res, SerializedError, SerializedRequest, SerializedResponse } from 'pino-std-serializers';
 
-declare function PinoHttp<IM = IncomingMessage, SR = ServerResponse, CustomLevels extends string = never>(opts?: Options<IM, SR>, stream?: pino.DestinationStream): HttpLogger<IM, SR, CustomLevels>;
+declare function PinoHttp< IM = IncomingMessage, SR = ServerResponse, Opts = Options<IM, SR>>(opts?: Opts, stream?: pino.DestinationStream): HttpLogger<IM, SR, Opts>;
 
 declare function PinoHttp<IM = IncomingMessage, SR = ServerResponse>(stream?: pino.DestinationStream): HttpLogger<IM, SR>;
 
-export interface HttpLogger<IM = IncomingMessage, SR = ServerResponse, CustomLevels extends string = never> {
-    (req: IM, res: SR, next?: () => void): void;
-    logger: pino.Logger<CustomLevels>;
+export interface HttpLogger<
+  IM = IncomingMessage,
+  SR = ServerResponse,
+  Opts = Options<IM, SR>
+> {
+  (req: IM, res: SR, next?: () => void): void;
+  logger: pino.Logger<
+    Opts extends { customLevels?: infer C1 } & {
+      logger?: { customLevels?: infer C2 };
+    }
+      ? keyof C1 | keyof C2
+      : never
+  >;
 }
 export type ReqId = number | string | object;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -206,10 +206,21 @@ const httpServerListener: RequestListener = (request, response) => {
   response.end("Hello world");
 };
 
-// custom levels added in the options should be available
+// custom levels added in the options should be available/typesafe
 // on the logger returned by pino-http
-pinoHttp<IncomingMessage, ServerResponse, 'bark'>({
-    customLevels: {
-        bark: 25,
-    }
-}).logger.bark("arf arf");
+pinoHttp({ customLevels: { bark: 25 } }).logger.bark("arf arf");
+
+// custom levels added to the logger passed in the options should be available/typesafe
+pinoHttp({ logger: pino({ customLevels: { bark: 35 } }) }).logger.bark(
+  "arf arf"
+);
+
+// if custom levels are passed in both the customLevels option and via the logger
+// all the levels should be available/typesafe
+const { logger: customLevelsLogger } = pinoHttp({
+  logger: pino({ customLevels: { meow: 35 } }),
+  customLevels: { bark: 25 },
+});
+
+customLevelsLogger.meow("meow meow");
+customLevelsLogger.bark("arf arf");


### PR DESCRIPTION
pass in logger's generic based on value of customLevels and/or logger.customLevels option

fixes #317 and supersedes https://github.com/pinojs/pino-http/pull/318 if merged

cc @UndefinedBehaviour @GeoffreyEmerson 