### PR TITLE
feat: added responseTime argument to the custom errorMessage callback

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -119,7 +119,7 @@ function pinoLogger (opts, stream) {
           [errKey]: error,
           [responseTimeKey]: responseTime
         }),
-        errorMessage(req, res, error)
+        errorMessage(req, res, error, responseTime)
       )
 
       return

--- a/test/test.js
+++ b/test/test.js
@@ -947,6 +947,26 @@ test('pass responseTime argument to the custom successMessage callback', functio
   })
 })
 
+test('pass responseTime argument to the custom errorMessage callback', function (t) {
+  const dest = split(JSON.parse)
+  const customErrorMessage = 'Response time is:'
+  const logger = pinoHttp({
+    customErrorMessage: function (req, res, err, responseTime) {
+      return `${customErrorMessage} ${responseTime} ${req.method}`
+    }
+  }, dest)
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server, ERROR_URL)
+  })
+
+  dest.on('data', function (line) {
+    t.match(line.msg, /Response time is: \d+ GET/)
+    t.end()
+  })
+})
+
 test('uses the custom successObject callback if passed in as an option', function (t) {
   const dest = split(JSON.parse)
   const logger = pinoHttp({


### PR DESCRIPTION
Similar to issue #199, this PR adds the responseTime argument to the custom errorMessage callback to provide more informative error logs.