### PR TITLE
feat: add quietResLogger option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ $ node example.js | pino-pretty
 * `wrapSerializers`: when `false`, custom serializers will be passed the raw value directly. Defaults to `true`.
 * `customProps`: set to a `function (req, res) => { /* returns on object */ }` or `{ /* returns on object */ }` This function will be invoked for each request with `req` and `res` where we could pass additional properties that need to be logged outside the `req`.
 * `quietReqLogger`: when `true`, the child logger available on `req.log` will no longer contain the full bindings and will now only have the request id bound at `reqId` (note: the autoLogging messages and the logger available on `res.log` will remain the same except they will also have the additional `reqId` property). default: `false`
+* `quietResLogger`: when `true`, the child logger available on `res.log` will no longer contain the full bindings and will now only have the request id bound at `reqId` (note: the autoLogging message sent on request completion will only contain `req`). default: `false`
 
 `stream`: the destination stream. Could be passed in as an option too.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,6 +39,7 @@ export interface Options<IM = IncomingMessage, SR = ServerResponse, CustomLevels
     wrapSerializers?: boolean | undefined;
     customProps?: ((req: IM, res: SR) => object) | undefined;
     quietReqLogger?: boolean | undefined;
+    quietResLogger?: boolean | undefined;
 }
 
 export interface GenReqId<IM = IncomingMessage, SR = ServerResponse> {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -155,6 +155,7 @@ const options: Options = {
   wrapSerializers: canBeUndefined(rtnBool()),
   customProps: canBeUndefined((req: IncomingMessage, res: ServerResponse) => ({} as object)),
   quietReqLogger: canBeUndefined(rtnBool()),
+  quietResLogger: canBeUndefined(rtnBool()),
 }
 
 // can't pass 'useLevel' and 'customLogLevel' together

--- a/logger.js
+++ b/logger.js
@@ -77,6 +77,7 @@ function pinoLogger (opts, stream) {
   delete opts.customErroredMessage
 
   const quietReqLogger = !!opts.quietReqLogger
+  const quietResLogger = !!opts.quietResLogger
 
   const logger = wrapChild(opts, theStream)
 
@@ -147,7 +148,7 @@ function pinoLogger (opts, stream) {
       fullReqLogger = fullReqLogger.child(customPropBindings)
     }
 
-    const responseLogger = fullReqLogger
+    const responseLogger = quietResLogger ? log : fullReqLogger
     const requestLogger = quietReqLogger ? log : fullReqLogger
 
     if (!res.log) {

--- a/test/test.js
+++ b/test/test.js
@@ -1464,3 +1464,60 @@ test('quiet request logging - custom request id key', function (t) {
     })
   }, handler)
 })
+
+test('quiet response logging', function (t) {
+  t.plan(5)
+  const dest = split(JSON.parse)
+  const logger = pinoHttp({ quietResLogger: true }, dest)
+
+  function handler (req, res) {
+    t.pass('called')
+    req.id = 'testId'
+    logger(req, res)
+    req.log.info('quiet message')
+    res.end('hello world')
+  }
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server, null, function () {
+      dest.read()
+
+      const responseLine = dest.read()
+      t.equal(responseLine.msg, DEFAULT_REQUEST_COMPLETED_MSG)
+      t.notOk(responseLine.req)
+      t.ok(responseLine.res)
+
+      t.end()
+    })
+  }, handler)
+})
+
+test('quiet request and response logging', function (t) {
+  t.plan(6)
+  const dest = split(JSON.parse)
+  const logger = pinoHttp({ quietReqLogger: true, quietResLogger: true }, dest)
+
+  function handler (req, res) {
+    t.pass('called')
+    req.id = 'testId'
+    logger(req, res)
+    req.log.info('quiet message')
+    res.end('hello world')
+  }
+
+  setup(t, logger, function (err, server) {
+    t.error(err)
+    doGet(server, null, function () {
+      dest.read()
+
+      const responseLine = dest.read()
+      t.equal(responseLine.msg, DEFAULT_REQUEST_COMPLETED_MSG)
+      t.equal(responseLine.reqId, 'testId')
+      t.notOk(responseLine.req)
+      t.ok(responseLine.res)
+
+      t.end()
+    })
+  }, handler)
+})


### PR DESCRIPTION
Applies similar logic as `quietReqLogger` to determine which logger instance to use.

Fixes #235