### PR TITLE
fix: allow using non-lowercased custom levels

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -42,7 +42,7 @@ function pinoLogger (opts, stream) {
 
   function getValidLogLevel (level, defaultValue = 'info') {
     if (level && typeof level === 'string') {
-      const logLevel = level.trim().toLowerCase()
+      const logLevel = level.trim()
       if (validLogLevels.includes(logLevel) === true) {
         return logLevel
       }

--- a/test/test.js
+++ b/test/test.js
@@ -223,10 +223,10 @@ test('uses the log level passed in as an option, where the level is a custom one
   const logger = pinoHttp(
     {
       customLevels: {
-        custom: 25
+        infoCustom: 25
       },
-      useLevel: 'custom',
-      level: 'custom'
+      useLevel: 'infoCustom',
+      level: 'infoCustom'
     },
     dest
   )


### PR DESCRIPTION
The code failed to use `useLevel` when the custom level was, for example, camel-cased. 

I updated the test to reflect this occasional scenario and removed the unnecessary transformation of the log level.