### PR TITLE
feat(types): add responseTime parameter to customErrorMessage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ export interface Options<IM = IncomingMessage, SR = ServerResponse, CustomLevels
     customLogLevel?: ((req: IM, res: SR, error?: Error) => pino.LevelWithSilent | CustomLevels) | undefined;
     customReceivedMessage?: ((req: IM, res: SR) => string) | undefined;
     customSuccessMessage?: ((req: IM, res: SR, responseTime: number) => string) | undefined;
-    customErrorMessage?: ((req: IM, res: SR, error: Error) => string) | undefined;
+    customErrorMessage?: ((req: IM, res: SR, error: Error, responseTime: number) => string) | undefined;
     customReceivedObject?: ((req: IM, res: SR, val?: any) => any) | undefined;
     customSuccessObject?: ((req: IM, res: SR, val: any) => any) | undefined;
     customErrorObject?: ((req: IM, res: SR, error: Error, val: any) => any) | undefined;


### PR DESCRIPTION
## Description
Add responseTime parameter to customErrorMessage type definition to allow access to the request's response time when creating custom error messages.

## Changes
- Updated TypeScript type definition for customErrorMessage to include responseTime parameter
- Response time is provided in milliseconds, consistent with pino-http's existing timing

## Example Usage
```typescript
const logger = pinoHttp({
  customErrorMessage: (req, res, err, responseTime) => {
    return `${err.message} (took ${responseTime}ms)`;
  }
});