### PR TITLE
ci(ci): move to fastify shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,79 +1,25 @@
 name: CI
 
 on:
-  workflow_dispatch:
   push:
+    branches:
+     - main
+     - next
+     - 'v*'
     paths-ignore:
-        - 'docs/**'
-        - '*.md'
+      - 'docs/**'
+      - '*.md'
   pull_request:
     paths-ignore:
-        - 'docs/**'
-        - '*.md'
-
-# This allows a subsequently queued workflow run to interrupt previous runs
-concurrency:
-  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
-  cancel-in-progress: true
+      - 'docs/**'
+      - '*.md'
 
 jobs:
-  dependency-review:
-    name: Dependency Review
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Dependency review
-        uses: actions/dependency-review-action@v4
-
   test:
-    name: Test
-    runs-on: ubuntu-latest
     permissions:
-      contents: read
-    strategy:
-      matrix:
-        node-version: [18, 20, 22]
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Restore cached dependencies
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: node-modules-${{ hashFiles('package.json') }}
-
-      - name: Install dependencies
-        run: npm i --ignore-scripts
-
-      - name: Run tests
-        run: npm test
-
-  automerge:
-    name: Automerge Dependabot PRs
-    if: >
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.user.login == 'dependabot[bot]'
-    needs: test
-    permissions:
-      pull-requests: write
       contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: fastify/github-action-merge-dependabot@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      pull-requests: write
+    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v5
+    with:
+      license-check: true
+      node-versions: '["18", "20", "22"]'


### PR DESCRIPTION
This PR replaces the CI workflow with the Fastify shared workflow. It does the exact same thing, and the existing workflow was just a copy and paste of said shared workflow anyway.

Fastify and Pino are joined at the hip, with Pino being used as the default logger for Fastify and there being significant overlap in the maintainers/contributors of both projects, so changes to the shared workflows can be easily made to support both Fastify and Pino should they be required.