### PR TITLE
fix(types): add responseTime to customErrorMessage callback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ export interface Options<IM = IncomingMessage, SR = ServerResponse, CustomLevels
     customLogLevel?: ((req: IM, res: SR, error?: Error) => pino.LevelWithSilent | CustomLevels) | undefined;
     customReceivedMessage?: ((req: IM, res: SR) => string) | undefined;
     customSuccessMessage?: ((req: IM, res: SR, responseTime: number) => string) | undefined;
-    customErrorMessage?: ((req: IM, res: SR, error: Error) => string) | undefined;
+    customErrorMessage?: ((req: IM, res: SR, error: Error, responseTime: number) => string) | undefined;
     customReceivedObject?: ((req: IM, res: SR, val?: any) => any) | undefined;
     customSuccessObject?: ((req: IM, res: SR, val: any) => any) | undefined;
     customErrorObject?: ((req: IM, res: SR, error: Error, val: any) => any) | undefined;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -48,6 +48,9 @@ pinoHttp<CustomRequest, CustomResponse>({ customSuccessMessage: (req: CustomRequ
 // #customErrorMessage
 pinoHttp({ customErrorMessage: (req: IncomingMessage, res: ServerResponse, error: Error) => `Error - ${error}` });
 pinoHttp<CustomRequest, CustomResponse>({ customErrorMessage: (req: CustomRequest, res: CustomResponse, error: Error) => `Error - ${error}` });
+pinoHttp({
+  customErrorMessage: (req, res, error, responseTime) => `Error - ${error.message} after ${responseTime}ms`
+});
 
 // #customAttributeKeys
 pinoHttp({ customAttributeKeys: { req: 'req' } });
@@ -232,4 +235,7 @@ pinoHttp({
 pinoHttp({
   logger: customLogger,
   customLogLevel: () => 'bark'
+})
+pinoHttp({
+  customErrorMessage: (req, res, error, responseTime) => `Error - ${error.message} after ${responseTime}ms`
 })


### PR DESCRIPTION
Fixes #359

Updated the `customErrorMessage` type definition to include the 4th argument `responseTime`.

This allows users to make full use of all parameters passed to `customErrorMessage`.

- Updated `Options` interface in `index.d.ts`
- Added test case to `index.test-d.ts` using 4 parameters
