### PR TITLE
fix(types): narrow ReqId to string|number

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ $ node example.js | pino-pretty
 `opts`: it has all the options as [pino](http://npm.im/pino) and
 
 * `logger`: parent pino instance for a child logger instance, which will be used by `pino-http`. To refer to this child instance, use [pinoHttp.logger](#pinohttplogger-plogger)
-* `genReqId`: you can pass a function which gets used to generate a request id. The first argument is the request itself. As fallback `pino-http` is just using an integer. This default might not be the desired behavior if you're running multiple instances of the app
+* `genReqId`: you can pass a function which gets used to generate a request id. The arguments are `(req, res)` and the function should return a `string` or `number`. As fallback `pino-http` is just using an integer. This default might not be the desired behavior if you're running multiple instances of the app
 * `useLevel`: the logger level `pino-http` is using to log out the response. default: `info`
 * `customLogLevel`: set to a `function (req, res, err) => { /* returns level name string */ }`. This function will be invoked to determine the level at which the log should be issued (`silent` will prevent logging). This option is mutually exclusive with the `useLevel` option. The first two arguments are the HTTP request and response. The third argument is an error object if an error has occurred in the request.
 * `autoLogging`: set to `false`, to disable the automatic "request completed" and "request errored" logging. Defaults to `true`. If set to an object, you can provide more options.

--- a/import.test-d.ts
+++ b/import.test-d.ts
@@ -1,7 +1,8 @@
-import { expectType } from 'tsd';
+import { expectNotAssignable, expectType } from 'tsd';
 
+import { IncomingMessage, ServerResponse } from 'http';
 import pino from 'pino';
-import pinoHttp, { HttpLogger } from '.';
+import pinoHttp, { GenReqId, HttpLogger } from '.';
 import { pinoHttp as pinoHttpNamed } from '.';
 import * as pinoHttpStar from '.';
 import pinoHttpCjsImport = require ('.');
@@ -23,3 +24,6 @@ expectType<HttpLogger>(pinoHttpCjsImport.default());
 expectType<HttpLogger>(pinoHttpCjsImport.pinoHttp());
 expectType<any>(pinoHttpCjs());
 expectType<any>(pinoHttpCjsNamed());
+
+expectNotAssignable<GenReqId>((_req: IncomingMessage, _res: ServerResponse) => Buffer.allocUnsafe(16));
+expectNotAssignable<GenReqId>((_req: IncomingMessage, _res: ServerResponse) => ({ id: 'nope' }));

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ export interface HttpLogger<IM = IncomingMessage, SR = ServerResponse, CustomLev
     (req: IM, res: SR, next?: () => void): void;
     logger: pino.Logger<CustomLevels>;
 }
-export type ReqId = number | string | object;
+export type ReqId = number | string;
 
 export interface Options<IM = IncomingMessage, SR = ServerResponse, CustomLevels extends string = never> extends pino.LoggerOptions {
     logger?: pino.Logger<CustomLevels> | undefined;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -27,8 +27,8 @@ pinoHttp<CustomRequest, CustomResponse>({ logger });
 pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => req.statusCode || 200 });
 pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => res.statusCode || 200 });
 pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => 'foo' });
-pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => Buffer.allocUnsafe(16) });
-pinoHttp<CustomRequest, CustomResponse>({ genReqId: (req: CustomRequest, res: CustomResponse) => Buffer.allocUnsafe(16) });
+pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => `${res.statusCode || 200}` });
+pinoHttp<CustomRequest, CustomResponse>({ genReqId: (req: CustomRequest, res: CustomResponse) => `${req.context}-${res.context}` });
 
 // #useLevel
 pinoHttp({ useLevel: 'error' });
@@ -110,10 +110,8 @@ const rtnLevel = () => {
 
 const genReqId: GenReqId = () => {
   let rtn: ReqId = 123;
-  if (rand()){
+  if (rand()) {
     rtn = 'str';
-  } else {
-    rtn = ({} as object);
   }
   return rtn;
 }


### PR DESCRIPTION
## Summary
- narrow `ReqId` type from `number | string | object` to `number | string`
- update type tests to remove object/Buffer req id acceptance
- add tsd negative assignability assertions for invalid `GenReqId` return types
- update README `genReqId` docs to specify `(req, res)` and `string | number` return

Fixes #268