### PR TITLE
fix: add missing responseTime parameter to customErrorMessage type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ export interface Options<IM = IncomingMessage, SR = ServerResponse, CustomLevels
     customLogLevel?: ((req: IM, res: SR, error?: Error) => pino.LevelWithSilent | CustomLevels) | undefined;
     customReceivedMessage?: ((req: IM, res: SR) => string) | undefined;
     customSuccessMessage?: ((req: IM, res: SR, responseTime: number) => string) | undefined;
-    customErrorMessage?: ((req: IM, res: SR, error: Error) => string) | undefined;
+    customErrorMessage?: ((req: IM, res: SR, error: Error, responseTime: number) => string) | undefined;
     customReceivedObject?: ((req: IM, res: SR, val?: any) => any) | undefined;
     customSuccessObject?: ((req: IM, res: SR, val: any) => any) | undefined;
     customErrorObject?: ((req: IM, res: SR, error: Error, val: any) => any) | undefined;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -47,6 +47,7 @@ pinoHttp<CustomRequest, CustomResponse>({ customSuccessMessage: (req: CustomRequ
 
 // #customErrorMessage
 pinoHttp({ customErrorMessage: (req: IncomingMessage, res: ServerResponse, error: Error) => `Error - ${error}` });
+pinoHttp({ customErrorMessage: (req: IncomingMessage, res: ServerResponse, error: Error, responseTime: number) => `Error - ${error} (${responseTime}ms)` });
 pinoHttp<CustomRequest, CustomResponse>({ customErrorMessage: (req: CustomRequest, res: CustomResponse, error: Error) => `Error - ${error}` });
 
 // #customAttributeKeys
@@ -148,7 +149,7 @@ const options: Options = {
     return `Received HTTP ${req.httpVersion} ${req.method}`;
   }),
   customSuccessMessage: canBeUndefined((req: IncomingMessage, res: ServerResponse) => 'successMessage'),
-  customErrorMessage: canBeUndefined((req: IncomingMessage, res: ServerResponse, error: Error) => 'errorMessage'),
+  customErrorMessage: canBeUndefined((req: IncomingMessage, res: ServerResponse, error: Error, responseTime: number) => 'errorMessage'),
   customAttributeKeys: canBeUndefined(customAttributeKeys),
   wrapSerializers: canBeUndefined(rtnBool()),
   customProps: canBeUndefined((req: IncomingMessage, res: ServerResponse) => ({} as object)),


### PR DESCRIPTION
## Summary

The `customErrorMessage` callback receives 4 arguments at runtime (`req`, `res`, `error`, `responseTime`) in [logger.js:128](https://github.com/pinojs/pino-http/blob/master/logger.js#L128), but the TypeScript declaration in `index.d.ts` only declared 3 parameters — missing `responseTime: number`.

This is inconsistent with `customSuccessMessage`, which already includes `responseTime` in its type declaration.

### Changes

- **index.d.ts**: Added `responseTime: number` parameter to `customErrorMessage` type
- **index.test-d.ts**: Added type test with `responseTime` parameter, updated combined options test

### Verification

- All 64 existing tests pass
- Type tests (`tsd`) pass
- 100% code coverage maintained

Closes #359