### PR TITLE
fix: avoid duplicate keys when customProps() differs at request-finish

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { pino, symbols: { stringifySym, chindingsSym } } = require('pino')
+const { pino } = require('pino')
 const serializers = require('pino-std-serializers')
 const getCallerFile = require('get-caller-file')
 const startTime = Symbol('startTime')
@@ -107,13 +107,17 @@ function pinoLogger (opts, stream) {
       return
     }
 
+    // `logger` here is the request-scoped logger *without* customProps applied
+    // (see loggingMiddleware below) so it's safe to bind customProps exactly
+    // once, using the freshest req/res state available at response-finish
+    // time. Binding on top of an already-customProps-bound logger (as this
+    // used to do) could produce duplicate keys in the output whenever
+    // customProps() legitimately returns different values between the
+    // request-start and response-finish calls (e.g. properties that depend
+    // on data only available once the request has been routed/handled).
     const customPropBindings = (typeof customProps === 'function') ? customProps(req, res) : customProps
     if (customPropBindings) {
-      const customPropBindingStr = logger[stringifySym](customPropBindings).replace(/[{}]/g, '')
-      const customPropBindingsStr = logger[chindingsSym]
-      if (!customPropBindingsStr.includes(customPropBindingStr)) {
-        log = logger.child(customPropBindings)
-      }
+      log = logger.child(customPropBindings)
     }
 
     if (err || res.err || res.statusCode >= 500) {
@@ -147,7 +151,8 @@ function pinoLogger (opts, stream) {
 
     const log = quietReqLogger ? logger.child({ [requestIdKey]: req.id }) : logger
 
-    let fullReqLogger = log.child({ [reqKey]: req })
+    const baseReqLogger = log.child({ [reqKey]: req })
+    let fullReqLogger = baseReqLogger
     const customPropBindings = (typeof customProps === 'function') ? customProps(req, res) : customProps
     if (customPropBindings) {
       fullReqLogger = fullReqLogger.child(customPropBindings)
@@ -155,6 +160,12 @@ function pinoLogger (opts, stream) {
 
     const responseLogger = quietResLogger ? log : fullReqLogger
     const requestLogger = quietReqLogger ? log : fullReqLogger
+    // Logger passed to onResFinished for the completion/error log line. It
+    // intentionally does *not* have customProps applied yet (unlike
+    // responseLogger above, which is used for logging during the request) so
+    // that onResFinished can apply customProps exactly once, using the
+    // freshest req/res state, without duplicating keys already bound above.
+    const finishLogger = quietResLogger ? log : baseReqLogger
 
     if (!res.log) {
       res.log = responseLogger
@@ -180,7 +191,7 @@ function pinoLogger (opts, stream) {
       res.removeListener('close', onResponseComplete)
       res.removeListener('finish', onResponseComplete)
       res.removeListener('error', onResponseComplete)
-      return onResFinished(res, responseLogger, err)
+      return onResFinished(res, finishLogger, err)
     }
 
     if (autoLogging) {

--- a/test/test.js
+++ b/test/test.js
@@ -1421,6 +1421,41 @@ test('uses custom request properties and once customProps', function (t, end) {
   })
 })
 
+test('customProps returning different values between request start and response finish does not duplicate keys', function (t, end) {
+  const dest = split()
+
+  // Simulates a common real-world pattern (e.g. NestJS/Express apps): a
+  // property that is only known once request-handling middleware further
+  // down the chain has run, so customProps() legitimately returns a
+  // different value when called again at response-finish time.
+  function customPropsHandler (req, res) {
+    return {
+      route: req.matchedRoute || 'unknown'
+    }
+  }
+
+  const logger = pinoHttp({
+    customProps: customPropsHandler
+  }, dest)
+
+  setup(t, logger, function (err, server) {
+    assert.equal(err, undefined)
+    doGet(server)
+  }, function (req, res) {
+    logger(req, res, noop)
+    req.matchedRoute = '/api/widgets/:id'
+    res.end('hello world')
+  })
+
+  dest.on('data', function (line) {
+    const parsed = JSON.parse(line)
+    if (parsed.msg !== DEFAULT_REQUEST_COMPLETED_MSG) return
+    assert.equal(line.match(/"route"/g).length, 1, 'route key appears exactly once')
+    assert.equal(parsed.route, '/api/widgets/:id', 'uses the freshest value, not the stale early one')
+    end()
+  })
+})
+
 test('dont pass custom request properties to log additional attributes', function (t, end) {
   const dest = split(JSON.parse)
   const logger = pinoHttp({


### PR DESCRIPTION
Fixes #216.

## The problem

`customProps()` is called twice: once at request start (bound onto `req.log`/`res.log` for use during the request) and again at response-finish, so the completion log line can reflect state that's only known once the response is done (this is intentional — see the existing "when response provided" test, which expects the completion line to show the *final* `res.statusCode`, not the one from request start).

The finish-time call currently binds its result on top of a logger that already has the request-start result bound in. There's a best-effort dedup check (comparing a stringified version of the new props against the logger's existing pino-internal `chindings`) that silently handles the common case where `customProps()` happens to return the *same* value both times. But whenever it legitimately returns a *different* value between the two calls — e.g. a property that depends on request state only set by later middleware (route/handler name, auth context, etc.), which is exactly the kind of use case people want `customProps` for — both bindings end up in the serialized output, producing duplicate keys. This is effectively what's been reported (in various shapes) in #216 over the years; the fix merged in #288 only covered the constant-value case.

Minimal repro (not included in the diff, just for illustration):
```js
const logger = pinoHttp({
  customProps: (req, res) => ({ route: req.matchedRoute || 'unknown' })
})

app.use(logger)
app.use((req, res, next) => { req.matchedRoute = '/api/widgets/:id'; next() })
```
Completion log line before this fix:
```json
{"route":"unknown","route":"/api/widgets/:id", ...}
```

## The fix

Keep the logger instance that's threaded through to the response-finish handler free of `customProps` (it still carries the request binding, so `req.log`/`res.log` behavior *during* the request is completely unchanged). The finish handler then applies `customProps` exactly once, using the freshest `req`/`res` state — so there's structurally no way for it to duplicate a binding that isn't there yet. This also let me drop the old `stringifySym`/`chindingsSym`-based dedup hack entirely, since it's no longer needed.

## Testing

- Reproduced the duplicate-key output against unpatched `master` with a `customProps()` that depends on request state set between pino-http's own middleware and the route handler.
- Confirmed the fix resolves it, and that the original constant-value case from #216 (and the existing test for it) still works correctly (no duplication, single binding).
- Added a regression test (`customProps returning different values between request start and response finish does not duplicate keys`) that fails on unpatched `master` and passes with this fix.
- Full suite: 65/66 pass, identical to `master` before this change — the one failure (`test/transport-integration.js`) reproduces the same way on unpatched `master` too (an async-activity-after-test-end issue in the transport worker teardown on this machine), unrelated to this change.
- `eslint`, `tsc`, and `tsd` all clean.

## Disclosure

Put together with AI assistance (Claude); I read through the relevant code paths myself, wrote/ran the repros and the regression test, and diffed against unpatched `master` before opening this.