### PR TITLE
feat: preserve Express errors in automatic logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,29 @@ function handle (req, res) {
 app.listen(3000)
 ```
 
+To preserve the original Express error in automatic completion logs, mount the
+same logger instance's `express` error middleware after the routes and before
+the application's error handler:
+
+```js
+const express = require('express')
+const httpLogger = require('pino-http')()
+
+const app = express()
+
+app.use(httpLogger)
+
+app.get('/', function (req, res) {
+  throw new Error('not happy')
+})
+
+app.use(httpLogger.express)
+
+app.use(function (err, req, res, next) {
+  res.status(500).send(err.message)
+})
+```
+
 ##### Logger options
 
 ```js

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ declare function PinoHttp<IM = IncomingMessage, SR = ServerResponse>(stream?: pi
 export interface HttpLogger<IM = IncomingMessage, SR = ServerResponse, CustomLevels extends string = never> {
     (req: IM, res: SR, next?: () => void): void;
     logger: pino.Logger<CustomLevels>;
+    express: (err: Error, req: IM, res: SR, next: (err: Error) => void) => void;
 }
 export type ReqId = number | string;
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -22,6 +22,8 @@ pinoHttp();
 pinoHttp({ logger });
 pinoHttp({ logger }).logger = logger;
 pinoHttp<CustomRequest, CustomResponse>({ logger });
+pinoHttp().express(new Error('boom'), {} as IncomingMessage, {} as ServerResponse, (err: Error) => {});
+pinoHttp<CustomRequest, CustomResponse>().express(new Error('boom'), {} as CustomRequest, {} as CustomResponse, (err: Error) => {});
 
 // #genReqId
 pinoHttp({ genReqId: (req: IncomingMessage, res: ServerResponse) => req.statusCode || 200 });

--- a/logger.js
+++ b/logger.js
@@ -90,6 +90,10 @@ function pinoLogger (opts, stream) {
     return loggingMiddleware(logger, req, res, next)
   }
   result.logger = logger
+  result.express = (err, req, res, next) => {
+    res.err = err
+    return next(err)
+  }
   return result
 
   function onResFinished (res, logger, err) {

--- a/test/test.js
+++ b/test/test.js
@@ -116,6 +116,31 @@ test('exposes the internal pino', function (t, end) {
   logger.logger.info('hello world')
 })
 
+test('express error middleware preserves the original error', function (t, end) {
+  const dest = split(JSON.parse)
+  const logger = pinoHttp(dest)
+  const error = new Error('not happy')
+
+  setup(t, logger, function (err, server) {
+    assert.equal(err, undefined)
+    doGet(server)
+  }, function (req, res) {
+    logger(req, res)
+    logger.express(error, req, res, function (nextError) {
+      assert.equal(nextError, error)
+      assert.equal(res.err, error)
+      res.statusCode = 500
+      res.end('error')
+    })
+  })
+
+  dest.on('data', function (line) {
+    assert.equal(line.err.message, error.message)
+    assert.equal(line.err.stack, error.stack)
+    end()
+  })
+})
+
 test('internal pino logger not shared between multiple middleware', function (t) {
   const dest = split(JSON.parse)
   const middleware1 = pinoHttp(dest)


### PR DESCRIPTION
## Summary

- add an Express error middleware to preserve the original application error on the response
- forward the same error to the remaining Express error handlers without registering duplicate log listeners
- document the middleware ordering and cover the runtime and TypeScript contracts

## Why

Express response completion events do not expose an error after the application error handler has processed it. This lets pino-http use the original error instead of synthesizing a generic status-code error for automatic logs.

## Testing

- npm test
- 65 tests passed, 1 existing test skipped
- 100% statement, branch, function, and line coverage for logger.js
- TypeScript, tsd, and ts-node validation passed

Closes #348